### PR TITLE
Feature/random commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 .idea
 match_log.txt
 client_secret.json
+*.iml

--- a/RioBot.py
+++ b/RioBot.py
@@ -32,7 +32,7 @@ async def on_ready():
     mm.refresh_queue.start(bot)
     gspread_client.refresh_api_data.start()
 
-    cog_files = ["web_stat_lookup", "game_stat_lookup", "misc", "submit_results", "memes"]
+    cog_files = ["web_stat_lookup", "game_stat_lookup", "misc", "submit_results", "memes", "randomize_commands"]
 
     for cog in cog_files:
         await bot.load_extension("cogs." + cog)

--- a/cogs/randomize_commands.py
+++ b/cogs/randomize_commands.py
@@ -33,11 +33,12 @@ class RandomizeCommands(commands.Cog):
         self.client = client
 
     @commands.command(name="random", help="Random Baseball Functions. Please use `!random help` for more info")
-    @commands.cooldown(1, 20, commands.BucketType.default)
+    @commands.cooldown(1, 15, commands.BucketType.default)
     async def random(self, ctx, command, qualifier=""):
         command = command.lower()
         qualifier = qualifier.lower()
         if "help" in command:
+            ctx.command.reset_cooldown(ctx)
             embed = discord.Embed(title="Random Commands Help", description=random_help_string)
             await ctx.send(embed=embed)
         elif command == "character" or command == "chara" or command == "char":
@@ -86,6 +87,7 @@ class RandomizeCommands(commands.Cog):
                 # await ctx.send(title, file=discord.File(fp=image_binary, filename='image.png'))
 
         else:
+            ctx.command.reset_cooldown(ctx)
             embed = discord.Embed(description="Alas poor random command; I do not know thee well", color=hex_y)
             await ctx.send(embed=embed)
     # End random

--- a/cogs/randomize_commands.py
+++ b/cogs/randomize_commands.py
@@ -33,7 +33,7 @@ class RandomizeCommands(commands.Cog):
         self.client = client
 
     @commands.command(name="random", help="Random Baseball Functions. Please use `!random help` for more info")
-    @commands.cooldown(1, 15, commands.BucketType.user)
+    @commands.cooldown(1, 20, commands.BucketType.default)
     async def random(self, ctx, command, qualifier=""):
         command = command.lower()
         qualifier = qualifier.lower()

--- a/cogs/randomize_commands.py
+++ b/cogs/randomize_commands.py
@@ -1,0 +1,157 @@
+from io import BytesIO
+
+import discord
+from discord.ext import commands
+
+from helpers.image_builder import buildTeamImageHighlightCaptain
+from services.random_functions import *
+from helpers.team_sorter import sortTeamsByTier
+
+# Random Cog Properties
+hex_y = 0xE8E337        # Error message
+hex_r = 0xF46D75        # Success message
+
+NL = "\n"
+random_help_string = "Here is a list of random commands you can use and their functions:" + NL \
+                + "`!random teams` - Generate two random teams with no dupes but random variants" + NL \
+                + "`!random teams dupes` - Generate two random teams with dupes enabled" + NL \
+                + "`!random teams balanced` - Generate two broadly balanced teams" + NL \
+                + "`!random teams power` - Generate two teams with top tier characters and distributed pitching" + NL \
+                + "`!random stadium` - Returns a random stadium" + NL \
+                + "`!random character` - Returns a random character" + NL \
+                + "`!random mode` - Returns a random game type for you to play" + NL \
+                + "`!pick options...` - Picks an option randomly" + NL \
+                + "`!pickmany N options...` - Picks N options randomly" + NL \
+                + "`!shuffle options...` - Shuffles options and returns them" + NL \
+                + "`!coin` - Flip a coin" + NL \
+                + "`!roll N` - Roll a die of N sides"
+
+
+# Cog Class
+class RandomizeCommands(commands.Cog):
+    def __init__(self, client):
+        self.client = client
+
+    @commands.command(name="random", help="Random Baseball Functions. Please use `!random help` for more info")
+    @commands.cooldown(1, 15, commands.BucketType.user)
+    async def random(self, ctx, command, qualifier=""):
+        command = command.lower()
+        qualifier = qualifier.lower()
+        if "help" in command:
+            embed = discord.Embed(title="Random Commands Help", description=random_help_string)
+            await ctx.send(embed=embed)
+        elif command == "character" or command == "chara" or command == "char":
+            embed = discord.Embed(title=rfRandomCharacter(), color=hex_r)
+            await ctx.send(embed=embed)
+        elif command == "stadium":
+            embed = discord.Embed(title=rfRandomStadium(), color=hex_r)
+            await ctx.send(embed=embed)
+        elif command == "mode" or command == "modes":
+            embed = discord.Embed(title=rfRandomMode(), color=hex_r)
+            await ctx.send(embed=embed)
+        elif command == "teams":
+            if not qualifier or qualifier == "":
+                team_list = rfRandomTeamsWithoutDupes()
+                title = "**Random Teams**"
+                description = "Pure random teams without dupes but random variants. Captains are highlighted."
+            elif "dupes" in qualifier:
+                team_list = rfRandomTeamsWithDupes()
+                title = "**Random Teams with Dupes** "
+                description = "Pure random teams with duplicates enabled. Captains are highlighted."
+            elif "balance" in qualifier:
+                team_list = rfRandomBalancedTeams()
+                title = "**Random Balanced Teams**"
+                description = "Random teams where each team is given a character from one of five broadly balanced " \
+                              "tiers until teams are filled. Captains are highlighted."
+            elif "power" in qualifier:
+                team_list = rfRandomPowerTeams()
+                title = "**Random Power Teams**"
+                description = "Random teams made from top characters exclusively. Duplicates are enabled. Each team " \
+                              "is guaranteed one meta pitcher. Captains are highlighted. "
+
+            captain_list = [team_list[0][0], team_list[1][0]]
+            team_list = sortTeamsByTier(team_list)
+
+            teams_image = buildTeamImageHighlightCaptain(team_list, captain_list)
+
+            with BytesIO() as image_binary:
+                teams_image.save(image_binary, 'PNG')
+                image_binary.seek(0)
+
+                file = discord.File(fp=image_binary, filename='image.png')
+                embed = discord.Embed(title=title, description=description, color=hex_r)
+                embed.set_image(url="attachment://image.png")
+                await ctx.send(file=file, embed=embed)
+
+                # await ctx.send(title, file=discord.File(fp=image_binary, filename='image.png'))
+
+        else:
+            embed = discord.Embed(description="Alas poor random command; I do not know thee well", color=hex_y)
+            await ctx.send(embed=embed)
+    # End random
+
+    @commands.command(name="pick", help="Pick one item from a list")
+    @commands.cooldown(1, 5, commands.BucketType.user)
+    async def pick(self, ctx, *arg):
+        if len(arg) > 1:
+            embed = discord.Embed(description=rfPickOne(arg), color=hex_r)
+            await ctx.send(embed=embed)
+        else:
+            embed = discord.Embed(description="Please give me more options than that", color=hex_y)
+            await ctx.send(embed=embed)
+    # End pick
+
+    @commands.command(name="pickmany", help="Pick N items from a list")
+    @commands.cooldown(1, 5, commands.BucketType.user)
+    async def pick_many(self, ctx, choices, *arg):
+        try:
+            pick_number = int(choices)
+            if len(arg) > 0 and pick_number < len(arg):
+                embed = discord.Embed(description=rfPickMany(pick_number, arg), color=hex_r)
+                await ctx.send(embed=embed)
+            else:
+                embed = discord.Embed(description="I don't think you quite know what you're asking", color=hex_y)
+                await ctx.send(embed=embed)
+        except ValueError:
+            embed = discord.Embed(description="Give me a number of choices to make. For example: `!pickmany 2 red "
+                                              "blue green`", color=hex_y)
+            await ctx.send(embed=embed)
+    # End pick many
+
+    @commands.command(name="shuffle", help="Shuffle the order of a list")
+    @commands.cooldown(1, 5, commands.BucketType.user)
+    async def shuffle(self, ctx, *arg):
+        if len(arg) > 1:
+            embed = discord.Embed(description=rfShuffle(arg), color=hex_r)
+            await ctx.send(embed=embed)
+        else:
+            embed = discord.Embed(description="No sense in shuffling that", color=hex_y)
+            await ctx.send(embed=embed)
+    # End shuffle
+
+    @commands.command(name="coin", help="Toss a coin to your witcher")
+    @commands.cooldown(1, 5, commands.BucketType.user)
+    async def coin(self, ctx):
+        embed = discord.Embed(title=rfFlipCoin(), color=hex_r)
+        await ctx.send(embed=embed)
+    # End coin
+
+    @commands.command(name="roll", help="Roll an N-sided die")
+    @commands.cooldown(1, 5, commands.BucketType.user)
+    async def roll(self, ctx, die):
+        try:
+            die_sides = int(die)
+            if die_sides > 2:
+                embed = discord.Embed(title=rfRollDice(die_sides), color=hex_r)
+                await ctx.send(embed=embed)
+            else:
+                embed = discord.Embed(description="I can't roll that in this dimension", color=hex_y)
+                await ctx.send(embed=embed)
+        except ValueError:
+            embed = discord.Embed(description="That isn't a dice", color=hex_y)
+            await ctx.send(embed=embed)
+    # End roll
+
+
+async def setup(client):
+    await client.add_cog(RandomizeCommands(client))

--- a/helpers/image_builder.py
+++ b/helpers/image_builder.py
@@ -1,0 +1,67 @@
+import requests
+from PIL import Image, ImageOps
+from resources.characters import images
+
+
+# Builds a composite image showing two team rosters displayed horizontally
+def buildTeamImage(teams):
+    team_one_icons = []
+    team_two_icons = []
+    for character in teams[0]:
+        team_one_icons.append(Image.open(requests.get(images[character.value], stream=True).raw))
+    for character in teams[1]:
+        team_two_icons.append(Image.open(requests.get(images[character.value], stream=True).raw))
+
+    total_width = 9*60
+    total_height = 2*60
+
+    teams_image = Image.new('RGBA', (total_width, total_height))
+    x_offset = 0
+    for icon in team_one_icons:
+        teams_image.paste(icon, (x_offset, 0))
+        x_offset += 60
+    x_offset = 0
+    for icon in team_two_icons:
+        teams_image.paste(icon, (x_offset, 60))
+        x_offset += 60
+
+    return teams_image
+# END buildTeamImage
+
+
+# Builds a composite image showing two team rosters displayed horizontally with the Captains highlighted cyan
+def buildTeamImageHighlightCaptain(teams, captains):
+    team_one_icons = []
+    team_two_icons = []
+    for character in teams[0]:
+        image = Image.open(requests.get(images[character.value], stream=True).raw).convert('RGBA')
+        if character in captains:
+            background = Image.new('RGBA', (56, 56))
+            bordered = ImageOps.expand(background, 2, (0, 255, 255))
+            bordered.paste(image, (0, 0), image)
+            image = bordered
+        team_one_icons.append(image)
+    for character in teams[1]:
+        image = Image.open(requests.get(images[character.value], stream=True).raw).convert('RGBA')
+        if character in captains:
+            background = Image.new('RGBA', (56, 56))
+            bordered = ImageOps.expand(background, 2, (0, 255, 255))
+            bordered.paste(image, (0, 0), image)
+            image = bordered
+        team_two_icons.append(image)
+
+    total_width = 9*60
+    total_height = 2*60
+
+    teams_image = Image.new('RGBA', (total_width, total_height))
+    x_offset = 0
+    for icon in team_one_icons:
+        teams_image.paste(icon, (x_offset, 0))
+        x_offset += 60
+    x_offset = 0
+    for icon in team_two_icons:
+        teams_image.paste(icon, (x_offset, 60))
+        x_offset += 60
+
+    return teams_image
+# END buildTeamImage

--- a/helpers/random_team_builder.py
+++ b/helpers/random_team_builder.py
@@ -1,0 +1,166 @@
+import copy
+from random import shuffle, choice
+from resources.characters import Char
+
+# General Character Lists
+all_captains = [Char.MARIO, Char.LUIGI, Char.PEACH, Char.DAISY, Char.YOSHI, Char.BIRDO, Char.DIDDY, Char.DK, Char.WALUIGI, Char.WARIO, Char.BOWSER_JR, Char.BOWSER]
+bro_list = [Char.BRO_H, Char.BRO_B, Char.BRO_F]
+mag_list = [Char.MAGIKOOPA_B, Char.MAGIKOOPA_G, Char.MAGIKOOPA_Y, Char.MAGIKOOPA_R]
+pianta_list = [Char.PIANTA_R, Char.PIANTA_B, Char.PIANTA_Y]
+noki_list = [Char.NOKI_R, Char.NOKI_B, Char.NOKI_G]
+paratroopa_list = [Char.PARATROOPA_G, Char.PARATROOPA_R]
+koopa_list = [Char.KOOPA_R, Char.KOOPA_G]
+shyguy_list = [Char.SHY_GUY_R, Char.SHY_GUY_B, Char.SHY_GUY_G, Char.SHY_GUY_Y, Char.SHY_GUY_BK]
+drybones_list = [Char.DRY_BONES_G, Char.DRY_BONES_R, Char.DRY_BONES_B, Char.DRY_BONES_GY]
+toad_list = [Char.TOAD_R, Char.TOAD_B, Char.TOAD_G, Char.TOAD_P, Char.TOAD_Y]
+
+# 32 Character Random, Random Variant
+pnd_characters = [Char.BOWSER, Char.PETEY, Char.DK, bro_list, Char.YOSHI, Char.BIRDO, Char.BOO, Char.KING_BOO, mag_list, Char.WALUIGI, Char.WARIO, Char.TOADSWORTH, pianta_list, Char.MARIO, Char.LUIGI,
+                  Char.DIDDY, Char.DIXIE, noki_list, paratroopa_list, Char.DAISY, Char.TOADETTE, Char.BOWSER_JR, shyguy_list, drybones_list, Char.PEACH, koopa_list, toad_list, Char.MONTY,
+                  Char.BABY_MARIO, Char.BABY_LUIGI, Char.GOOMBA, Char.PARAGOOMBA]
+
+
+def pickFromPool(team, pool):
+    next_pick = pool.pop()
+    if isinstance(next_pick, list):
+        team.append(choice(next_pick))
+    else:
+        team.append(next_pick)
+# END pickfromPool
+
+
+def pickFromSpecializedPool(team, specialized_pool, pool):
+    shuffle(specialized_pool)
+    team.append(specialized_pool.pop())
+    pool.remove(team[-1])
+# END pickFromSpecializedPool
+
+
+def pureRandomTeams(team_one, team_two, pool, captains, pitchers=None):
+
+    shuffle(captains)
+    pickFromSpecializedPool(team_one, captains, pool)
+    pickFromSpecializedPool(team_two, captains, pool)
+
+    if pitchers:
+        if team_one[0] in pitchers and team_two[0] not in pitchers:
+            pitchers.remove(team_one[0])
+            pickFromSpecializedPool(team_two, pitchers, pool)
+        elif team_two[0] in pitchers and team_one[0] not in pitchers:
+            pitchers.remove(team_two[0])
+            pickFromSpecializedPool(team_one, pitchers, pool)
+        elif team_one[0] not in pitchers and team_two[0] not in pitchers:
+            pickFromSpecializedPool(team_two, pitchers, pool)
+            pickFromSpecializedPool(team_one, pitchers, pool)
+
+        if len(team_one) > len(team_two):
+            pickFromPool(team_two, pool)
+        elif len(team_two) > len(team_one):
+            pickFromPool(team_one, pool)
+
+    shuffle(pool)
+    while len(team_one) + len(team_two) < 18:
+        pickFromPool(team_one, pool)
+        pickFromPool(team_two, pool)
+# END pureRandomTeams
+
+
+def randomTeamsWithoutDupes():
+    first_team = []
+    second_team = []
+    pureRandomTeams(first_team, second_team, copy.deepcopy(pnd_characters), copy.deepcopy(all_captains))
+    return [first_team, second_team]
+# END randomTeamsWithoutDupes
+
+
+def randomTeamsWtihDupes():
+    first_team = []
+    second_team = []
+    all_characters = []
+    for char in Char:
+        all_characters.append(char)
+    shuffle(all_characters)
+    pureRandomTeams(first_team, second_team, all_characters, copy.deepcopy(all_captains))
+    return [first_team, second_team]
+# END randomTeamsWithDupes
+
+
+# Broad Balanced Tiers
+tier_0 = [Char.BOWSER, Char.PETEY, Char.DK, Char.BRO_H, Char.BRO_B, Char.BRO_F, Char.YOSHI, Char.BIRDO, Char.BOO, Char.KING_BOO]
+tier_1 = [Char.MAGIKOOPA_B, Char.MAGIKOOPA_R, Char.MAGIKOOPA_G, Char.MAGIKOOPA_Y, Char.WALUIGI, Char.TOADSWORTH, Char.MARIO,
+          Char.WARIO, Char.PIANTA_R, Char.LUIGI, Char.DIDDY, Char.DIXIE]
+tier_2 = [Char.NOKI_G, Char.PARATROOPA_G, Char.TOADETTE, Char.BOWSER_JR, Char.DRY_BONES_G, Char.DAISY, Char.PIANTA_Y, Char.PIANTA_B,
+          Char.NOKI_B, Char.NOKI_R, Char.PEACH, Char.SHY_GUY_R]
+tier_3 = [Char.DRY_BONES_R, Char.SHY_GUY_G, Char.TOAD_R, Char.SHY_GUY_BK, Char.SHY_GUY_B, Char.SHY_GUY_Y, Char.KOOPA_G,
+          Char.MONTY, Char.PARATROOPA_R, Char.KOOPA_R]
+tier_4 = [Char.DRY_BONES_GY, Char.DRY_BONES_B, Char.TOAD_B, Char.TOAD_G, Char.TOAD_P, Char.TOAD_Y, Char.BABY_MARIO, Char.BABY_LUIGI,
+          Char.GOOMBA, Char.PARAGOOMBA]
+
+balanced_brackets = [tier_0.copy(), tier_1.copy(), tier_2.copy(), tier_3.copy(), tier_4.copy()]
+balanced_captains = {Char.BOWSER: 0, Char.DK: 0, Char.YOSHI: 0, Char.BIRDO: 0, Char.WALUIGI: 1, Char.WARIO: 1, Char.MARIO: 1,
+                     Char.LUIGI: 1, Char.DIDDY: 1, Char.DAISY: 2, Char.BOWSER_JR: 2, Char.PEACH: 2}
+
+
+def pickFromBrackets(team_one, team_two, brackets):
+    shuffle(brackets)
+    tier = brackets.pop()
+    if len(tier) > 1:
+        team_one.append(tier.pop())
+        team_two.append(tier.pop())
+        if len(tier) > 1:
+            brackets.append(tier)
+# END pickFromBrackets
+
+
+def pickBalancedCaptains(team_one, team_two, captain_dict, brackets):
+    # Assign captains
+    captain_list = list(captain_dict.keys())
+    shuffle(captain_list)
+    team_one.append(captain_list[0])
+    team_two.append(captain_list[1])
+
+    team_one_cap_tier = captain_dict[team_one[0]]
+    team_two_cap_tier = captain_dict[team_two[0]]
+    brackets[team_one_cap_tier].remove(team_one[0])
+    brackets[team_two_cap_tier].remove(team_two[0])
+
+    # Balance Teams
+    if team_one_cap_tier == team_two_cap_tier:
+        return
+
+    team_two.append(brackets[team_one_cap_tier].pop())
+    team_one.append(brackets[team_two_cap_tier].pop())
+# END pickBalancedCaptains
+
+
+def pickBalancedTeams(team_one, team_two, brackets, captain_dict):
+    pickBalancedCaptains(team_one, team_two, captain_dict, brackets)
+
+    while len(team_one) + len(team_two) < 18:
+        pickFromBrackets(team_one, team_two, brackets)
+# End pickBalancedTeams
+
+
+def randomBalancedTeams():
+    first_team = []
+    second_team = []
+    pickBalancedTeams(first_team, second_team, copy.deepcopy(balanced_brackets), copy.deepcopy(balanced_captains))
+
+    return [first_team, second_team]
+# END randomBalancedTeams
+
+
+# Power Team Definitions
+power_characters = [Char.BOWSER, Char.DK, Char.PETEY, Char.BIRDO, Char.BOO, Char.BRO_H, Char.YOSHI, Char.KING_BOO, Char.BRO_B,
+                    Char.BRO_F, Char.MAGIKOOPA_B, Char.MAGIKOOPA_R, Char.MAGIKOOPA_G, Char.MAGIKOOPA_Y, Char.WALUIGI, Char.WARIO, Char.MARIO,
+                    Char.LUIGI, Char.PIANTA_R, Char.DIXIE, Char.DIDDY, Char.TOADSWORTH, Char.NOKI_G, Char.PARATROOPA_G]
+power_captains = [Char.BOWSER, Char.DK, Char.BIRDO, Char.YOSHI, Char.WALUIGI, Char.WARIO, Char.MARIO, Char.LUIGI, Char.DIDDY]
+power_pitchers = [Char.BOO, Char.DIXIE, Char.DIDDY, Char.WALUIGI]
+
+
+def randomPowerTeams():
+    first_team = []
+    second_team = []
+    pureRandomTeams(first_team, second_team, copy.deepcopy(power_characters), copy.deepcopy(power_captains), copy.deepcopy(power_pitchers))
+    return [first_team, second_team]
+# END randomPowerTeams

--- a/helpers/random_team_builder.py
+++ b/helpers/random_team_builder.py
@@ -105,6 +105,7 @@ def pickFromBrackets(team_one, team_two, brackets):
     shuffle(brackets)
     tier = brackets.pop()
     if len(tier) > 1:
+        shuffle(tier)
         team_one.append(tier.pop())
         team_two.append(tier.pop())
         if len(tier) > 1:

--- a/helpers/team_sorter.py
+++ b/helpers/team_sorter.py
@@ -1,0 +1,85 @@
+from resources.characters import Char
+
+ranked_character_dict = {
+    Char.BOWSER.value: 1,
+    Char.PETEY.value: 2,
+    Char.DK.value: 3,
+    Char.BRO_H.value: 4,
+    Char.BRO_B.value: 4,
+    Char.YOSHI.value: 5,
+    Char.BIRDO.value: 6,
+    Char.BOO.value: 7,
+    Char.KING_BOO.value: 8,
+    Char.BRO_F.value: 9,
+    Char.MAGIKOOPA_B.value: 10,
+    Char.MAGIKOOPA_R.value: 10,
+    Char.MAGIKOOPA_G.value: 10,
+    Char.MAGIKOOPA_Y.value: 10,
+    Char.WALUIGI.value: 11,
+    Char.TOADSWORTH.value: 12,
+    Char.MARIO.value: 13,
+    Char.WARIO.value: 14,
+    Char.PIANTA_R.value: 15,
+    Char.LUIGI.value: 16,
+    Char.DIDDY.value: 17,
+    Char.DIXIE.value: 17,
+    Char.NOKI_G.value: 18,
+    Char.PARATROOPA_G.value: 19,
+    Char.TOADETTE.value: 20,
+    Char.BOWSER_JR.value: 21,
+    Char.DRY_BONES_G.value: 22,
+    Char.DAISY.value: 23,
+    Char.PIANTA_B.value: 24,
+    Char.PIANTA_Y.value: 24,
+    Char.NOKI_B.value: 25,
+    Char.NOKI_R.value: 25,
+    Char.PEACH.value: 26,
+    Char.SHY_GUY_R.value: 27,
+    Char.SHY_GUY_G.value: 27,
+    Char.DRY_BONES_R.value: 28,
+    Char.TOAD_R.value: 29,
+    Char.SHY_GUY_B.value: 30,
+    Char.SHY_GUY_Y.value: 30,
+    Char.SHY_GUY_BK.value: 30,
+    Char.KOOPA_G.value: 31,
+    Char.MONTY.value: 32,
+    Char.PARATROOPA_R.value: 33,
+    Char.KOOPA_R.value: 34,
+    Char.DRY_BONES_B.value: 35,
+    Char.DRY_BONES_GY.value: 35,
+    Char.TOAD_B.value: 36,
+    Char.TOAD_P.value: 36,
+    Char.TOAD_G.value: 36,
+    Char.TOAD_Y.value: 36,
+    Char.BABY_MARIO.value: 37,
+    Char.BABY_LUIGI.value: 37,
+    Char.GOOMBA.value: 38,
+    Char.PARAGOOMBA.value: 38
+}
+
+
+def getCharacterRank(char):
+    if isinstance(char, Char):
+        return ranked_character_dict[char.value]
+    else:
+        if char in ranked_character_dict:
+            return ranked_character_dict[char]
+        else:
+            return 99   # Put any unknown characters at end of list
+# END getCharacterRank
+
+
+def sortTeamsByTier(teams):
+    for team in teams:
+        team.sort(key=getCharacterRank)
+    return teams
+# END Sort Teams By Tier Exclude Captain
+
+
+def sortTeamsByTierExcludeCaptain(teams):
+    for team in teams:
+        captain = team.pop(0)
+        team.sort(key=getCharacterRank)
+        team.insert(0, captain)
+    return teams
+# END Sort Teams By Tier Exclude Captain

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+discord.py==2.1.0
+glicko2==2.0.0
+gspread==5.7.1
+oauth2client==4.1.3
+Pillow==9.3.0
+python-dotenv==0.21.0
+requests==2.28.1

--- a/resources/EnvironmentVariables.py
+++ b/resources/EnvironmentVariables.py
@@ -1,7 +1,15 @@
 import json
+from os.path import exists
+
+prod_env = 'resources/prod.json'
+dev_env = 'resources/test.json'
 
 
 def get_var(var_input: str):
-    with open('resources/prod.json') as config:
+    env = prod_env
+    if exists(dev_env):
+        env = dev_env
+
+    with open(env) as config:
         env_vars = json.loads(config.read())
         return env_vars[var_input]

--- a/resources/characters.py
+++ b/resources/characters.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 # Character ID mappings
 mappings = {
     0: "Mario",
@@ -322,6 +324,65 @@ aliases = {
     "b!bro": 53,
     "bbro": 53
 }
+
+
+# Character Enums
+class Char(Enum):
+    MARIO = "Mario"
+    LUIGI = "Luigi"
+    DK = "DK"
+    DIDDY = "Diddy"
+    PEACH = "Peach"
+    DAISY = "Daisy"
+    YOSHI = "Yoshi"
+    BABY_MARIO = "Baby Mario"
+    BABY_LUIGI = "Baby Luigi"
+    BOWSER = "Bowser"
+    WARIO = "Wario"
+    WALUIGI = "Waluigi"
+    KOOPA_R = "Koopa(R)"
+    TOAD_R = "Toad(R)"
+    BOO = "Boo"
+    TOADETTE = "Toadette"
+    SHY_GUY_R = "Shy Guy(R)"
+    BIRDO = "Birdo"
+    MONTY = "Monty"
+    BOWSER_JR = "Bowser Jr"
+    PARATROOPA_R = "Paratroopa(R)"
+    PIANTA_B = "Pianta(B)"
+    PIANTA_R = "Pianta(R)"
+    PIANTA_Y = "Pianta(Y)"
+    NOKI_B = "Noki(B)"
+    NOKI_R = "Noki(R)"
+    NOKI_G = "Noki(G)"
+    BRO_H = "Bro(H)"
+    TOADSWORTH = "Toadsworth"
+    TOAD_B = "Toad(B)"
+    TOAD_Y = "Toad(Y)"
+    TOAD_G = "Toad(G)"
+    TOAD_P = "Toad(P)"
+    MAGIKOOPA_B = "Magikoopa(B)"
+    MAGIKOOPA_R = "Magikoopa(R)"
+    MAGIKOOPA_G = "Magikoopa(G)"
+    MAGIKOOPA_Y = "Magikoopa(Y)"
+    KING_BOO = "King Boo"
+    PETEY = "Petey"
+    DIXIE = "Dixie"
+    GOOMBA = "Goomba"
+    PARAGOOMBA = "Paragoomba"
+    KOOPA_G = "Koopa(G)"
+    PARATROOPA_G = "Paratroopa(G)"
+    SHY_GUY_B = "Shy Guy(B)"
+    SHY_GUY_Y = "Shy Guy(Y)"
+    SHY_GUY_G = "Shy Guy(G)"
+    SHY_GUY_BK = "Shy Guy(Bk)"
+    DRY_BONES_GY = "Dry Bones(Gy)"
+    DRY_BONES_G = "Dry Bones(G)"
+    DRY_BONES_R = "Dry Bones(R)"
+    DRY_BONES_B = "Dry Bones(B)"
+    BRO_F = "Bro(F)"
+    BRO_B = "Bro(B)"
+
 
 images = {
     "Mario": "https://i.imgur.com/gX96BkX.png",

--- a/services/random_functions.py
+++ b/services/random_functions.py
@@ -1,0 +1,84 @@
+from random import shuffle, randint, choice, sample
+
+from helpers.random_team_builder import randomTeamsWithoutDupes, randomTeamsWtihDupes, randomBalancedTeams, \
+    randomPowerTeams
+from resources.characters import Char
+
+
+# Flip a coin
+def rfFlipCoin():
+    if randint(0, 1) == 0:
+        return "Heads"
+    return "Tails"
+
+
+# Roll a dice with DIE number of sides
+def rfRollDice(die):
+    if die > 1:
+        return randint(1, die)
+    return 1
+
+
+# Pick One from a set of arguments
+def rfPickOne(args):
+    return choice(args)
+
+
+# Pick N from a set of arguments. Picks all if N is equal too or greater than the number of arguments
+def rfPickMany(choices, args):
+    return sample(args, choices)
+
+
+# Shuffle a set of arguments. We convert to a list because *args is a TUPLE and therefore is immutable
+def rfShuffle(args):
+    shuffle_list = []
+    for arg in args:
+        shuffle_list.append(arg)
+    shuffle(shuffle_list)
+    return shuffle_list
+
+
+# Picks a random character from all 52 characters in the game
+def rfRandomCharacter():
+    characters = []
+    for char in Char:
+        characters.append(char.value)
+    shuffle(characters)
+    return characters.pop()
+
+
+# Picks a random stadium
+def rfRandomStadium():
+    stadiums = ["Mario Stadium", "Peach Garden", "Wario Palace", "Yoshi Park", "Donkey Kong Jungle", "Bowser Castle"]
+    shuffle(stadiums)
+    return stadiums.pop()
+
+
+# Decide on a random mode to play and where
+def rfRandomMode():
+    random_modes = ["random teams"
+                    , "random balanced teams"
+                    , "BIG BALLA"
+                    , "Tee Ball"]
+    shuffle(random_modes)
+    return "Play a game of " + random_modes.pop() + " at " + rfRandomStadium()
+
+
+# Return two random teams without dupes
+def rfRandomTeamsWithoutDupes():
+    return randomTeamsWithoutDupes()
+
+
+# Return two random teams with dupes
+def rfRandomTeamsWithDupes():
+    return randomTeamsWtihDupes()
+
+
+# Return two balanced teams
+def rfRandomBalancedTeams():
+    return randomBalancedTeams()
+
+
+# Return two power teams
+def rfRandomPowerTeams():
+    return randomPowerTeams()


### PR DESCRIPTION
This update adds a random commands cog to the RioBot. These commands include random teams, stadium, character, mode, as well as some helped commands like shuffle, pick, roll, and flip. This features **does not** add a random queue. It is intended as a "polished beta" since a random queue would require an agreed upon ruleset.

Three helper classes:

- **image builder:** uses the character imgur links to build a single image with two teams provided
- **team sorter:** roughly sorts teams by character strength making it easier to compare two random teams
- **random team builder:** the core code for crafting random teams

One service class:
- **random functions:** meant to separate as much logic from the randoms cog class as reasonable
 
Core random functionality includes:

```
- !random
- !random help
- !random teams
- !random teams dupes
- !random teams balanced
- !random teams power
- !random character
- !random stadium
- !random mode
- !roll <die>
- !flip
- !pick <args>
- !shuffle <args>
- !pickmany <N> <args>
```

The last few functions might seem superfluous but would be nice for classic draft drafting order and similar situations.

Also adds a "requirements.txt" for maintaining dependencies. 
Run "pip install -r requirements.txt" to verify all requirements are downloaded and satisfied