### PR TITLE
Fix ladder division by zero error

### DIFF
--- a/main/cogs/ladder.py
+++ b/main/cogs/ladder.py
@@ -30,7 +30,7 @@ class Ladder(commands.Cog):
                 buffer3 = " " * (7 - len(str(round(user["adjusted_rating"]))))
                 buffer4 = " " * (8 - (len(str(user["num_wins"])) + len(str(user["num_losses"]))))
 
-                try:
+                if user["num_wins"] + user["num_losses"] > 0:
                     win_pct = user["num_wins"] / (user["num_wins"] + user["num_losses"]) * 100
                 else:
                     win_pct = 0

--- a/main/cogs/ladder.py
+++ b/main/cogs/ladder.py
@@ -25,6 +25,8 @@ class Ladder(commands.Cog):
             message = "**" + mode + " Ladder**\n```"
             message += "#    Username          Rtg    W/L      Pct\n"
             for index, user in enumerate(ladder_values):
+                if user["num_wins"] == 0 and user["num_losses"] == 0:
+                    continue
                 buffer1 = " " * (4 - len(str(index + 1)))
                 buffer2 = " " * (18 - len(user["username"]))
                 buffer3 = " " * (7 - len(str(round(user["adjusted_rating"]))))

--- a/main/cogs/ladder.py
+++ b/main/cogs/ladder.py
@@ -30,7 +30,10 @@ class Ladder(commands.Cog):
                 buffer3 = " " * (7 - len(str(round(user["adjusted_rating"]))))
                 buffer4 = " " * (8 - (len(str(user["num_wins"])) + len(str(user["num_losses"]))))
 
-                win_pct = user["num_wins"] / (user["num_wins"] + user["num_losses"]) * 100
+                try:
+                    win_pct = user["num_wins"] / (user["num_wins"] + user["num_losses"]) * 100
+                else:
+                    win_pct = 0
 
                 message += str(index + 1) + "." + buffer1 + user["username"] + buffer2 + str(round(user["adjusted_rating"])) \
                            + buffer3 + str(user["num_wins"]) + "-" + str(user["num_losses"]) + buffer4 + str(round(win_pct, 1)) + "%\n"

--- a/main/cogs/ladder.py
+++ b/main/cogs/ladder.py
@@ -66,7 +66,7 @@ class Ladder(commands.Cog):
             pos_gap = 3
 
             for index, user in enumerate(ladder_values):
-                if user["num_wins"] + user["num_losses"] < min_games:
+                if (user["num_wins"] == 0 and user["num_losses"] == 0) or (user["num_wins"] + user["num_losses"] < min_games):
                     continue
 
                 pos += 1


### PR DESCRIPTION
The handling of the win_pct is probably not necessary but might as well be thorough. This should both prevent the DivisionByZeroError and prevent the display of players with 0 games played.