### PR TITLE
Feature/s8 update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ main/client_secret.json
 *.iml
 main/resources/test_BACKUP.json
 /main/resources/test_BACKUP.json
+main/.env
+main/resources/test.json

--- a/main/matchmaking.py
+++ b/main/matchmaking.py
@@ -12,7 +12,7 @@ from services.random_functions import rfRandomTeamsWithoutDupes, rfRandomStadium
 from services.image_functions import ifBuildTeamImageFile
 from helpers import utils
 
-mode_list = [ladders.STARS_OFF_MODE, ladders.STARS_ON_MODE, ladders.BIG_BALLA_RANDOMS, ladders.STARS_OFF_MEGA, ladders.STARS_OFF_RANDOMS, ladders.STARS_OFF_HAZARDS]
+mode_list = [ladders.STARS_OFF_MODE, ladders.STARS_ON_MODE, ladders.BIG_BALLA_RANDOMS, ladders.STARS_OFF_RANDOMS, ladders.STARS_OFF_HAZARDS]
 
 # Constant for starting percentile range for matchmaking search
 BASE_PERCENTILE_RANGE = 0.5
@@ -360,7 +360,7 @@ async def check_for_match(bot: commands.Bot, game_type, user_id, min_rating, max
 
     global last_ping_time
 
-    if game_type == ladders.STARS_OFF_MODE or game_type == ladders.STARS_OFF_MEGA or game_type == ladders.STARS_OFF_RANDOMS:
+    if game_type == ladders.STARS_OFF_MODE or game_type == ladders.STARS_OFF_RANDOMS:
         role_id = "<@&998791156794150943>"
         role_name = "STARS-OFF"
     elif game_type == ladders.STARS_ON_MODE or game_type == ladders.BIG_BALLA_RANDOMS:

--- a/main/resources/ladders.py
+++ b/main/resources/ladders.py
@@ -20,9 +20,8 @@ all_modes_body = {
 all_modes = requests.post("https://api.projectrio.app/tag_set/list", json=all_modes_body).json()["Tag Sets"]
 
 STARS_OFF_MODE = "Stars Off, Season 8"
-STARS_ON_MODE = "Stars On Hazardous, Season 8"
+STARS_ON_MODE = "Stars On, Season 8"
 BIG_BALLA_RANDOMS = "Big Balla Randoms, Season 8"
-STARS_OFF_MEGA = "Stars Off Mega, Season 8"
 STARS_OFF_RANDOMS = "Stars Off Hazardous Randoms, Season 8"
 STARS_OFF_HAZARDS = "Stars Off Hazardous, Season 8"
 # STARS_ON_MODE = "Stars On, Season 6"
@@ -48,7 +47,6 @@ MODE_ALIASES = {
     STARS_OFF_MODE: ["off", "starsoff", "stoff", "ssoff"],
     STARS_ON_MODE: ["on", "starson", "ston", "stars", "sson"],
     BIG_BALLA_RANDOMS: ["bb", "bigballa", "balla", "big"],
-    STARS_OFF_MEGA: ["mega"],
     STARS_OFF_RANDOMS: ["randoms", "random", "rand"],
     STARS_OFF_HAZARDS: ["hazards", "hazardous"]
 }
@@ -57,7 +55,6 @@ ladders = {
     STARS_OFF_MODE: [],
     STARS_ON_MODE: [],
     BIG_BALLA_RANDOMS: [],
-    STARS_OFF_MEGA: [],
     STARS_OFF_RANDOMS: [],
     STARS_OFF_HAZARDS: []
 }


### PR DESCRIPTION
Updating ladders to be function. The root cause of the problem was _Stars On_ Hazardous, Season 8_ which is _Stars On, Season 8_ for some reason. Also **MEGA_MODE** doesn't pool at all.

As an aside we should probably update the refresh ladders method to only refresh a singular ladder passed in as a parameter. That way if a single ladder breaks for some reason, they aren't all broken.