### PR TITLE
Auto-Assigning Home/Away 1p/2p Stadium for all game modes

### DIFF
--- a/main/matchmaking.py
+++ b/main/matchmaking.py
@@ -7,7 +7,7 @@ import datetime as dt
 import pytz
 
 from resources import EnvironmentVariables as ev, ladders
-from services.random_functions import rfRandomTeamsWithoutDupes, rfRandomStadium, rfFlipCoin
+from services.random_functions import rfRandomTeamsWithoutDupes, rfRandomStadium, rfFlipCoin, rfRandomHazardsStadium
 from services.image_functions import ifBuildTeamImageFile
 from helpers import utils
 
@@ -321,6 +321,8 @@ async def check_for_match(bot: commands.Bot, game_type, user_id, min_rating, max
                         player_1 += "home)"
                         player_2 += "away)"
                     stadium = rfRandomStadium()
+                    if "Hazards" in game_type and "Mario" in stadium:
+                        stadium = rfRandomHazardsStadium()
                     embed.add_field(name=game_type + " match found!",
                                     value=player_1 + " vs " + player_2 + "\n\nFind matches in <#" + str(
                                         BUTTON_CHANNEL_ID) + ">")

--- a/main/matchmaking.py
+++ b/main/matchmaking.py
@@ -305,7 +305,7 @@ async def check_for_match(bot: commands.Bot, game_type, user_id, min_rating, max
                     embed.add_field(name="Stadium", value=stadium)
                     await channel.send("<@" + user_id + "> <@" + str(
                         best_match) + ">", embed=embed, file=file)
-                elif "Stars Off" in game_type:
+                else:
                     player_1 = match_queue[user_id]["Name"] + " ("
                     player_2 = match_queue[best_match]["Name"] + " ("
                     if rfFlipCoin() == "Heads":
@@ -327,13 +327,13 @@ async def check_for_match(bot: commands.Bot, game_type, user_id, min_rating, max
                     embed.add_field(name="Stadium", value=stadium)
                     await channel.send("<@" + user_id + "> <@" + str(
                         best_match) + ">", embed=embed)
-                else:
-                    embed.add_field(name=game_type + " match found!",
-                                    value=match_queue[user_id]["Name"] + " vs " + str(
-                                        match_queue[best_match]["Name"]) + "\n\nFind matches in <#" + str(
-                                        BUTTON_CHANNEL_ID) + ">")
-                    await channel.send("<@" + user_id + "> <@" + str(
-                        best_match) + ">", embed=embed)
+                # else:
+                #     embed.add_field(name=game_type + " match found!",
+                #                     value=match_queue[user_id]["Name"] + " vs " + str(
+                #                         match_queue[best_match]["Name"]) + "\n\nFind matches in <#" + str(
+                #                         BUTTON_CHANNEL_ID) + ">")
+                #     await channel.send("<@" + user_id + "> <@" + str(
+                #         best_match) + ">", embed=embed)
 
                 # Increment total match count
                 match_count[game_type] += 1

--- a/main/services/random_functions.py
+++ b/main/services/random_functions.py
@@ -56,10 +56,11 @@ def rfRandomStadium():
 
 # Decide on a random mode to play and where
 def rfRandomMode():
-    random_modes = ["random teams"
-                    , "random balanced teams"
+    random_modes = ["Superstars Off"
+                    , "Superstars On"
                     , "BIG BALLA"
-                    , "Tee Ball"]
+                    , "Superstars Off Hazards"
+                    , "Remixed"]
     shuffle(random_modes)
     return "Play a game of " + random_modes.pop() + " at " + rfRandomStadium()
 

--- a/main/services/random_functions.py
+++ b/main/services/random_functions.py
@@ -54,6 +54,12 @@ def rfRandomStadium():
     return stadiums.pop()
 
 
+def rfRandomHazardsStadium():
+    stadiums = ["Peach Garden", "Wario Palace", "Yoshi Park", "DK Jungle", "Bowser Castle"]
+    shuffle(stadiums)
+    return stadiums.pop()
+
+
 # Decide on a random mode to play and where
 def rfRandomMode():
     random_modes = ["Superstars Off"


### PR DESCRIPTION
- Auto assigns home and away for all game modes (Technically didn't get sign off for Big Balla, but who is going to complain)
- Ensures Mario stadium doesn't get assigned for Hazards
- Pre-emptively updates the random modes function to be consistent with what quickplay will be assigning.