### PR TITLE
Infrastructure overhaul: aiohttp migration, Pydantic models, bug fixes, and deploy improvements

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -26,6 +26,8 @@ files:
     destination: /home/ec2-user/RioBot/main
   - source: scripts
     destination: /home/ec2-user/RioBot/scripts
+  - source: requirements.txt
+    destination: /home/ec2-user/RioBot
 # For deployments to Amazon Linux, Ubuntu Server, or RHEL instances,
 #   you can specify a "permissions"
 #   section here that describes special permissions to apply to the files

--- a/main/RioBot.py
+++ b/main/RioBot.py
@@ -3,6 +3,7 @@
 
 import os
 
+import aiohttp
 from discord.ext import commands, tasks
 from dotenv import load_dotenv
 import discord
@@ -16,8 +17,20 @@ load_dotenv()
 token = os.getenv("BOT_TOKEN")
 intents = discord.Intents.all()
 
+cog_files = ["web_stat_lookup", "game_stat_lookup", "misc", "memes", "randomize_commands", "ladder", "recent_games", "classic_teams", "submit_results"]
+
+
+class RioBot(commands.Bot):
+    async def setup_hook(self):
+        self.session = aiohttp.ClientSession()
+        ladders.set_session(self.session)
+        for cog in cog_files:
+            await self.load_extension("cogs." + cog)
+            print("%s has loaded." % cog)
+
+
 # initialize the bot commands with the associated prefix
-bot = commands.Bot(command_prefix="!", intents=intents, case_insensitive=True)
+bot = RioBot(command_prefix="!", intents=intents, case_insensitive=True)
 
 
 @bot.event
@@ -27,17 +40,12 @@ async def on_ready():
     # Initialize matchmaking buttons
     await mm.init_buttons(bot)
 
-    # Start timed tasks
+    # Start timed tasks — guarded so reconnects don't raise RuntimeError
     # mm.refresh_queue.start(bot)
-#    gspread_client.refresh_api_data.start()
-    ladders.refresh_ladders.start()
-    handle_crash.start()
-
-    cog_files = ["web_stat_lookup", "game_stat_lookup", "misc", "memes", "randomize_commands", "ladder", "recent_games", "classic_teams", "submit_results"]
-
-    for cog in cog_files:
-        await bot.load_extension("cogs." + cog)
-        print("%s has loaded." % cog)
+    if not ladders.refresh_ladders.is_running():
+        ladders.refresh_ladders.start()
+    if not handle_crash.is_running():
+        handle_crash.start()
 
 
 @tasks.loop(minutes=1)

--- a/main/cogs/ladder.py
+++ b/main/cogs/ladder.py
@@ -1,14 +1,7 @@
 from discord.ext import commands
 import discord
-import requests
 import urllib.parse
 from resources import EnvironmentVariables as ev, ladders
-
-modes_body = {
-    "communities": 1,
-    "active": True
-}
-modes = requests.post("https://api.projectrio.app/tag_set/list", data=modes_body).json()["Tag Sets"]
 
 
 class Ladder(commands.Cog):

--- a/main/cogs/recent_games.py
+++ b/main/cogs/recent_games.py
@@ -1,7 +1,7 @@
 import discord
-import requests
 from discord.ext import commands
 from resources import ladders
+from models.game import Game
 
 BASE_GAMES_URL = "https://api.projectrio.app/games/"
 
@@ -21,7 +21,7 @@ class RecentGames(commands.Cog):
 
     @commands.command(help="display a user's recent games")
     @commands.cooldown(1, 2, commands.BucketType.user)
-    async def last(self, ctx, num_games: int = 10, user: str = "all", mode: str = "off"):
+    async def last(self, ctx, num_games: int = 10, user: str = "all", mode: str = "all"):
         if num_games > 40:
             num_games = 40
         web_mode = ladders.get_web_mode(mode)
@@ -32,37 +32,38 @@ class RecentGames(commands.Cog):
         if user != "all":
             api_url += f"&username={user}"
 
-        games_data = requests.get(api_url).json()
+        async with self.client.session.get(api_url) as response:
+            games_data = await response.json(content_type=None)
+        games = [Game.model_validate(g) for g in games_data["games"]]
 
         message = ""
         emojis = ctx.message.guild.emojis
-        embed = discord.Embed(title=f"{mode} last {len(games_data['games'])} games for {user}")
-        for index, game in enumerate(games_data["games"]):
-            if game["home_user"].lower() == user.lower():
-                user = game["home_user"]
-                user_score = game["home_score"]
-                user_captain = next((e for e in emojis if e.name.lower() == game["home_captain"].replace(" ", "").lower()), "")
-                opp_user = game["away_user"]
-                opp_score = game["away_score"]
-                opp_captain = next((e for e in emojis if e.name.lower() == game["away_captain"].replace(" ", "").lower()), "")
+        embed = discord.Embed(title=f"{mode} last {len(games)} games for {user}")
+        for index, game in enumerate(games):
+            if game.home_user.lower() == user.lower():
+                user = game.home_user
+                user_score = game.home_score
+                user_captain = next((e for e in emojis if e.name.lower() == game.home_captain.replace(" ", "").lower()), "")
+                opp_user = game.away_user
+                opp_score = game.away_score
+                opp_captain = next((e for e in emojis if e.name.lower() == game.away_captain.replace(" ", "").lower()), "")
             else:
-                user = game["away_user"]
-                user_score = game["away_score"]
-                user_captain = next((e for e in emojis if e.name.lower() == game["away_captain"].replace(" ", "").lower()), "")
-                opp_user = game["home_user"]
-                opp_score = game["home_score"]
-                opp_captain = next((e for e in emojis if e.name.lower() == game["home_captain"].replace(" ", "").lower()), "")
-            timestamp = game["date_time_start"]
+                user = game.away_user
+                user_score = game.away_score
+                user_captain = next((e for e in emojis if e.name.lower() == game.away_captain.replace(" ", "").lower()), "")
+                opp_user = game.home_user
+                opp_score = game.home_score
+                opp_captain = next((e for e in emojis if e.name.lower() == game.home_captain.replace(" ", "").lower()), "")
             if user_score > opp_score:
-                message += f"<t:{timestamp}:d> {user_captain} **{user}** {user_score} - {opp_score} {opp_user} {opp_captain}"
+                message += f"<t:{game.date_time_start}:d> {user_captain} **{user}** {user_score} - {opp_score} {opp_user} {opp_captain}"
             else:
-                message += f"<t:{timestamp}:d> {user_captain} {user} {user_score} - {opp_score} **{opp_user}** {opp_captain}"
-            if game["innings_played"] != game["innings_selected"]:
-                message += " (F/" + str(game["innings_played"]) + ")"
-            stadium = stadium_map[game["stadium"]]
+                message += f"<t:{game.date_time_start}:d> {user_captain} {user} {user_score} - {opp_score} **{opp_user}** {opp_captain}"
+            if game.innings_played != game.innings_selected:
+                message += " (F/" + str(game.innings_played) + ")"
+            stadium = stadium_map[game.stadium]
             message += f" @ *{stadium}*\n"
             if mode == "all":
-                message += f" ({ladders.get_game_mode_name(game['game_mode'])})\n"
+                message += f" ({await ladders.get_game_mode_name(game.game_mode)})\n"
 
             if (index + 1) % 5 == 0:
                 embed.add_field(name="", value=message, inline=False)
@@ -81,40 +82,41 @@ class RecentGames(commands.Cog):
             web_mode = ladders.get_web_mode(mode)
             api_url += f"&tag={web_mode}"
 
-        games_data = requests.get(api_url).json()
+        async with self.client.session.get(api_url) as response:
+            games_data = await response.json(content_type=None)
+        games = [Game.model_validate(g) for g in games_data["games"]]
 
         message = ""
         emojis = ctx.message.guild.emojis
-        embed = discord.Embed(title=f"Last {len(games_data['games'])} games for {user1} vs {user2}")
-        for index, game in enumerate(games_data["games"]):
-            if game["home_user"].lower() == user1.lower():
-                user1 = game["home_user"]
-                user_score = game["home_score"]
+        embed = discord.Embed(title=f"Last {len(games)} games for {user1} vs {user2}")
+        for index, game in enumerate(games):
+            if game.home_user.lower() == user1.lower():
+                user1 = game.home_user
+                user_score = game.home_score
                 user_captain = next(
-                    (e for e in emojis if e.name.lower() == game["home_captain"].replace(" ", "").lower()), "")
-                opp_user = game["away_user"]
-                opp_score = game["away_score"]
+                    (e for e in emojis if e.name.lower() == game.home_captain.replace(" ", "").lower()), "")
+                opp_user = game.away_user
+                opp_score = game.away_score
                 opp_captain = next(
-                    (e for e in emojis if e.name.lower() == game["away_captain"].replace(" ", "").lower()), "")
+                    (e for e in emojis if e.name.lower() == game.away_captain.replace(" ", "").lower()), "")
             else:
-                user1 = game["away_user"]
-                user_score = game["away_score"]
+                user1 = game.away_user
+                user_score = game.away_score
                 user_captain = next(
-                    (e for e in emojis if e.name.lower() == game["away_captain"].replace(" ", "").lower()), "")
-                opp_user = game["home_user"]
-                opp_score = game["home_score"]
+                    (e for e in emojis if e.name.lower() == game.away_captain.replace(" ", "").lower()), "")
+                opp_user = game.home_user
+                opp_score = game.home_score
                 opp_captain = next(
-                    (e for e in emojis if e.name.lower() == game["home_captain"].replace(" ", "").lower()), "")
-            timestamp = game["date_time_start"]
+                    (e for e in emojis if e.name.lower() == game.home_captain.replace(" ", "").lower()), "")
             if user_score > opp_score:
-                message += f"<t:{timestamp}:d> {user_captain} **{user1}** {user_score} - {opp_score} {opp_user} {opp_captain}"
+                message += f"<t:{game.date_time_start}:d> {user_captain} **{user1}** {user_score} - {opp_score} {opp_user} {opp_captain}"
             else:
-                message += f"<t:{timestamp}:d> {user_captain} {user1} {user_score} - {opp_score} **{opp_user}** {opp_captain}"
-            if game["innings_played"] != game["innings_selected"]:
-                message += " (F/" + str(game["innings_played"]) + ")"
-            stadium = stadium_map[game["stadium"]]
+                message += f"<t:{game.date_time_start}:d> {user_captain} {user1} {user_score} - {opp_score} **{opp_user}** {opp_captain}"
+            if game.innings_played != game.innings_selected:
+                message += " (F/" + str(game.innings_played) + ")"
+            stadium = stadium_map[game.stadium]
             message += f" @ *{stadium}*"
-            message += f" ({ladders.get_game_mode_name(game['game_mode'])})\n"
+            message += f" ({await ladders.get_game_mode_name(game.game_mode)})\n"
 
             if (index + 1) % 5 == 0:
                 embed.add_field(name="", value=message, inline=False)

--- a/main/cogs/submit_results.py
+++ b/main/cogs/submit_results.py
@@ -2,7 +2,6 @@ import asyncio
 
 import discord.ext.commands
 from discord.ext import commands
-import requests
 import os
 
 from dotenv import load_dotenv
@@ -25,11 +24,12 @@ class SubmitResults(commands.Cog):
         manual_submit_rio_key = os.getenv("RIO_KEY")
 
         check_emoji = "\U00002705"
+        x_emoji = "\U0000274C"
         manual_submit_endpoint = "https://api.projectrio.app/manual_submit_game"
 
         if ctx.channel.id == RANKED_BOT_CHANNEL_ID:
             await ctx.message.add_reaction(check_emoji)
-            # requests.post()
+            await ctx.message.add_reaction(x_emoji)
 
             pokebunny_user_id = 117697656519786497
             pokebunny = await ctx.bot.fetch_user(pokebunny_user_id)
@@ -44,14 +44,17 @@ class SubmitResults(commands.Cog):
                 print("Could not DM Pokebunny")
 
             def check_confirm(rxn, usr):
-                return usr.name == "pokebunny" and (rxn.emoji == check_emoji)
+                return usr.name == "pokebunny" and rxn.emoji in (check_emoji, x_emoji) and rxn.message.id == ctx.message.id
 
             # Check for bot to see if a user confirmed or denied the results submitted by another user
             try:
-                await self.client.wait_for('reaction_add', timeout=86400.0, check=check_confirm)
+                reaction, _ = await self.client.wait_for('reaction_add', timeout=86400.0, check=check_confirm)
             except asyncio.TimeoutError:
                 await ctx.send("Game was not accepted within 24 hours")
             else:
+                if reaction.emoji == x_emoji:
+                    await ctx.send(f"Rejected: {user1} {score1} {score2} {user2} {game_mode_name}")
+                    return
                 manual_submit = {
                     "winner_username": user1,
                     "loser_username": user2,
@@ -63,7 +66,8 @@ class SubmitResults(commands.Cog):
                     "recalc": True
                 }
                 print(manual_submit)
-                response = requests.post(manual_submit_endpoint, json=manual_submit)
+                async with self.client.session.post(manual_submit_endpoint, json=manual_submit) as response:
+                    pass
                 await ctx.send(f"Submitted: {user1} {score1} {score2} {user2} {game_mode_name}")
                 # if response.status_code == 200:
                 #     await ctx.send(f"Submitted: {user1} {score1} {score2} {user2} {game_mode_name}")

--- a/main/cogs/web_stat_lookup.py
+++ b/main/cogs/web_stat_lookup.py
@@ -1,5 +1,4 @@
 import discord
-import requests
 from discord.ext import commands
 
 from helpers.offensive_stat_calcs import ostat_user_char, ostat_user, ostat_char, ostat_all
@@ -19,19 +18,20 @@ class WebStatLookup(commands.Cog):
         mode = ladders.get_web_mode(mode)
         if char.lower() in characters.aliases:
             char = characters.mappings[characters.aliases[char.lower()]]
+        session = self.client.session
         if char == "all" and user == "all":
-            await ostat_all(ctx, mode)
+            await ostat_all(ctx, mode, session)
         elif char == "all" and user != "all":
-            await ostat_user(ctx, user, mode)
+            await ostat_user(ctx, user, mode, session)
         elif char != "all" and user == "all":
-            await ostat_char(ctx, char, mode)
+            await ostat_char(ctx, char, mode, session)
         elif char != "all" and user != "all":
-            await ostat_user_char(ctx, user, char, mode)
+            await ostat_user_char(ctx, user, char, mode, session)
 
     @commands.command(name="orank", help="Get a ranking of all players offensively")
     async def o_rank(self, ctx, mode="off"):
         mode = ladders.get_web_mode(mode)
-        await ostat_char(ctx, "all", mode)
+        await ostat_char(ctx, "all", mode, self.client.session)
 
     @commands.command(name="pstat", help="Look up player pitching stats on Project Rio")
     @commands.cooldown(1, 5, commands.BucketType.user)
@@ -39,19 +39,20 @@ class WebStatLookup(commands.Cog):
         mode = ladders.get_web_mode(mode)
         if char.lower() in characters.aliases:
             char = characters.mappings[characters.aliases[char.lower()]]
+        session = self.client.session
         if char == "all" and user == "all":
-            await pstat_all(ctx, mode)
+            await pstat_all(ctx, mode, session)
         elif char == "all" and user != "all":
-            await pstat_user(ctx, user, mode)
+            await pstat_user(ctx, user, mode, session)
         elif char != "all" and user == "all":
-            await pstat_char(ctx, char, mode)
+            await pstat_char(ctx, char, mode, session)
         elif char != "all" and user != "all":
-            await pstat_user_char(ctx, user, char, mode)
+            await pstat_user_char(ctx, user, char, mode, session)
 
     @commands.command(name="prank", help="Get a ranking of all players defensively")
     async def p_rank(self, ctx, mode="off"):
         mode = ladders.get_web_mode(mode)
-        await pstat_char(ctx, "all", mode)
+        await pstat_char(ctx, "all", mode, self.client.session)
 
 
 async def setup(client):

--- a/main/helpers/offensive_stat_calcs.py
+++ b/main/helpers/offensive_stat_calcs.py
@@ -1,7 +1,9 @@
+import aiohttp
 import discord
-import requests
 from json import JSONDecodeError
 from resources import characters
+from models.batting_stats import BattingStats
+from models.misc_stats import MiscStats
 
 BASE_WEB_URL = "https://api.projectrio.app/stats/"
 
@@ -9,16 +11,18 @@ all_stats = {}
 all_by_char_stats = {}
 
 
-async def ostat_user_char(ctx, user: str, char: str, mode: str):
+async def ostat_user_char(ctx, user: str, char: str, mode: str, session: aiohttp.ClientSession):
     global all_by_char_stats
     try:
         all_by_char_url = f"{BASE_WEB_URL}?exclude_pitching=1&exclude_fielding=1&tag={mode}&by_char=1&exclude_nonfair=1"
         char_id = characters.reverse_mappings[char]
         url = f"{BASE_WEB_URL}?exclude_pitching=1&exclude_fielding=1&tag={mode}&char_id={char_id}&by_char=1&username={user}&exclude_nonfair=1"
-        response = requests.get(url).json()
+        async with session.get(url) as response:
+            data = await response.json(content_type=None)
         if not all_by_char_stats.get(mode, {}).get("Batting", {}):
-            all_by_char_stats[mode] = requests.get(all_by_char_url).json()["Stats"]
-        stats = response.get("Stats", {}).get(char, {}).get("Batting", {})
+            async with session.get(all_by_char_url) as response:
+                all_by_char_stats[mode] = (await response.json(content_type=None))["Stats"]
+        stats = BattingStats.model_validate(data.get("Stats", {}).get(char, {}).get("Batting", {}))
     except (JSONDecodeError, KeyError):
         embed = discord.Embed(
             title=f"There are no stats for user {user} with character {char} in {mode} or the user/character alias was not found.",
@@ -29,36 +33,36 @@ async def ostat_user_char(ctx, user: str, char: str, mode: str):
     pa, avg, obp, slg = calc_slash_line(stats)
     ops = obp + slg
 
-    all_char_stats = all_by_char_stats.get(mode, {}).get(char, {}).get("Batting", {})
+    all_char_stats = BattingStats.model_validate(all_by_char_stats.get(mode, {}).get(char, {}).get("Batting", {}))
     overall_pa, overall_avg, overall_obp, overall_slg = calc_slash_line(all_char_stats)
     ops_plus = ((obp / overall_obp) + (slg / overall_slg) - 1) * 100 if overall_obp > 0 and overall_slg > 0 else -100
 
-    misc = response.get("Stats", {}).get(char, {}).get("Misc", {})
-    games = misc["home_wins"] + misc["away_wins"] + misc["home_loses"] + misc["away_loses"]
-    winrate = (misc["home_wins"] + misc["away_wins"]) / games if games > 0 else 0
+    misc = MiscStats.model_validate(data.get("Stats", {}).get(char, {}).get("Misc", {}))
+    games = misc.home_wins + misc.away_wins + misc.home_loses + misc.away_loses
+    winrate = (misc.home_wins + misc.away_wins) / games if games > 0 else 0
 
     embed = discord.Embed(title=f"{user} - {char} ({pa} PA)")
     fields = [("G", str(games)),
               ("Win%", "{:.1f}".format(winrate * 100)),
-              ("AB", str(stats["summary_at_bats"])),
-              ("H", str(stats["summary_hits"])),
-              ("2B", str(stats["summary_doubles"])),
-              ("3B", str(stats["summary_triples"])),
-              ("HR", str(stats["summary_homeruns"])),
-              ("RBI", str(stats["summary_rbi"])),
-              ("\u200b", "\u200b"),
-              ("SO", str(stats["summary_strikeouts"])),
-              ("BB", str(stats["summary_walks_bb"] + stats["summary_walks_hbp"])),
-              ("\u200b", "\u200b"),
-              ("Perfect", str(stats["perfect_hits"])),
-              ("Nice", str(stats["nice_hits"])),
-              ("Sour", str(stats["sour_hits"])),
+              ("AB", str(stats.summary_at_bats)),
+              ("H", str(stats.summary_hits)),
+              ("2B", str(stats.summary_doubles)),
+              ("3B", str(stats.summary_triples)),
+              ("HR", str(stats.summary_homeruns)),
+              ("RBI", str(stats.summary_rbi)),
+              ("​", "​"),
+              ("SO", str(stats.summary_strikeouts)),
+              ("BB", str(stats.summary_walks_bb + stats.summary_walks_hbp)),
+              ("​", "​"),
+              ("Perfect", str(stats.perfect_hits)),
+              ("Nice", str(stats.nice_hits)),
+              ("Sour", str(stats.sour_hits)),
               ("AVG", "{:.3f}".format(avg)),
               ("OBP", "{:.3f}".format(obp)),
               ("SLG", "{:.3f}".format(slg)),
               ("OPS", "{:.3f}".format(ops)),
               ("cOPS+", str(round(ops_plus))),
-              ("\u200b", "\u200b")]
+              ("​", "​")]
 
     for name, value in fields:
         embed.add_field(name=name, value=value, inline=True)
@@ -68,7 +72,7 @@ async def ostat_user_char(ctx, user: str, char: str, mode: str):
     await ctx.send(embed=embed)
 
 
-async def ostat_user(ctx, user: str, mode: str):
+async def ostat_user(ctx, user: str, mode: str, session: aiohttp.ClientSession):
     await ctx.send(f"This information can now be accessed here: https://project-rio-frontend.vercel.app/user/{user}/batting")
     global all_stats, all_by_char_stats
     all_url = f"{BASE_WEB_URL}?exclude_pitching=1&exclude_fielding=1&exclude_misc=1&tag={mode}&exclude_nonfair=1"
@@ -78,27 +82,33 @@ async def ostat_user(ctx, user: str, mode: str):
     try:
         if not all_stats.get(mode, {}).get("Batting", {}):
             print("getting all stats")
-            all_stats[mode] = requests.get(all_url).json()["Stats"]
+            async with session.get(all_url) as response:
+                all_stats[mode] = (await response.json(content_type=None))["Stats"]
         if not all_by_char_stats.get(mode, {}):
             print("Getting all by char stats")
-            all_by_char_stats[mode] = requests.get(all_by_char_url).json()["Stats"]
-        user_response = requests.get(user_url).json()
-        user_by_char_response = requests.get(user_by_char_url).json()
-    except JSONDecodeError:
+            async with session.get(all_by_char_url) as response:
+                all_by_char_stats[mode] = (await response.json(content_type=None))["Stats"]
+        async with session.get(user_url) as response:
+            user_response = await response.json(content_type=None)
+        async with session.get(user_by_char_url) as response:
+            user_by_char_response = await response.json(content_type=None)
+    except (JSONDecodeError, KeyError):
         embed = discord.Embed(
             title=f"There are no stats for user {user} in {mode} or the username was not found.",
             color=0xEA7D07)
         await ctx.send(embed=embed)
         return
 
-    user_dict = {"all": user_response["Stats"]["Batting"]}
+    user_dict: dict[str, BattingStats] = {
+        "all": BattingStats.model_validate(user_response["Stats"]["Batting"])
+    }
     for char in user_by_char_response["Stats"]:
-        user_dict[char] = user_by_char_response["Stats"][char]["Batting"]
+        user_dict[char] = BattingStats.model_validate(user_by_char_response["Stats"][char]["Batting"])
 
     user_stats = user_dict["all"]
     pa, avg, obp, slg = calc_slash_line(user_stats)
 
-    _, _, overall_obp, overall_slg = calc_slash_line(all_stats[mode]["Batting"])
+    _, _, overall_obp, overall_slg = calc_slash_line(BattingStats.model_validate(all_stats[mode]["Batting"]))
     if overall_obp > 0 and overall_slg > 0:
         ops_plus = ((obp / overall_obp) + (slg / overall_slg) - 1) * 100
     else:
@@ -110,8 +120,8 @@ async def ostat_user(ctx, user: str, mode: str):
     del user_dict["all"]
     try:
         sorted_char_list = sorted(user_dict.keys(),
-                                  key=lambda x: user_dict[x]["summary_at_bats"] + user_dict[x]["summary_walks_bb"] +
-                                                user_dict[x]["summary_walks_hbp"] + user_dict[x]["summary_sac_flys"],
+                                  key=lambda x: user_dict[x].summary_at_bats + user_dict[x].summary_walks_bb +
+                                                user_dict[x].summary_walks_hbp + user_dict[x].summary_sac_flys,
                                   reverse=True)
     except KeyError:
         print("There was an error sorting the character list")
@@ -120,7 +130,7 @@ async def ostat_user(ctx, user: str, mode: str):
     for char in sorted_char_list:
         char_stats = user_dict[char]
         pa, avg, obp, slg = calc_slash_line(char_stats)
-        all_char_stats = all_by_char_stats[mode][char]["Batting"]
+        all_char_stats = BattingStats.model_validate(all_by_char_stats[mode][char]["Batting"])
         _, _, overall_obp, overall_slg = calc_slash_line(all_char_stats)
         if overall_obp > 0 and overall_slg > 0:
             ops_plus = ((obp / overall_obp) + (slg / overall_slg) - 1) * 100
@@ -135,7 +145,7 @@ async def ostat_user(ctx, user: str, mode: str):
     await ctx.send(embed=embed)
 
 
-async def ostat_char(ctx, char: str, mode: str):
+async def ostat_char(ctx, char: str, mode: str, session: aiohttp.ClientSession):
     try:
         all_url = f"{BASE_WEB_URL}?exclude_pitching=1&exclude_fielding=1&exclude_misc=1&tag={mode}&exclude_nonfair=1"
         if char != "all":
@@ -145,8 +155,10 @@ async def ostat_char(ctx, char: str, mode: str):
             char_url = all_url
             char_by_user_url = all_url + "&by_user=1"
 
-        char_response = requests.get(char_url).json()
-        char_by_user_response = requests.get(char_by_user_url).json()
+        async with session.get(char_url) as response:
+            char_response = await response.json(content_type=None)
+        async with session.get(char_by_user_url) as response:
+            char_by_user_response = await response.json(content_type=None)
     except (JSONDecodeError, KeyError):
         embed = discord.Embed(
             title=f"There are no stats for character {char} in {mode} or the character alias was not found.",
@@ -154,10 +166,11 @@ async def ostat_char(ctx, char: str, mode: str):
         await ctx.send(embed=embed)
         return
 
-    user_list = [("all", char_response["Stats"]["Batting"])]
-
+    user_list: list[tuple[str, BattingStats]] = [
+        ("all", BattingStats.model_validate(char_response["Stats"]["Batting"]))
+    ]
     for user, stats in char_by_user_response["Stats"].items():
-        user_list.append((user, stats["Batting"]))
+        user_list.append((user, BattingStats.model_validate(stats["Batting"])))
 
     char_stats = user_list[0][1]
     pa, avg, obp, slg = calc_slash_line(char_stats)
@@ -194,29 +207,34 @@ async def ostat_char(ctx, char: str, mode: str):
     await ctx.send(embed=embed)
 
 
-async def ostat_all(ctx, mode: str):
+async def ostat_all(ctx, mode: str, session: aiohttp.ClientSession):
     global all_stats, all_by_char_stats
     all_url = BASE_WEB_URL + "?exclude_pitching=1&exclude_fielding=1&exclude_nonfair=1&exclude_misc=1&tag=" + mode
     all_by_char_url = all_url + "&by_char=1"
 
-    all_stats[mode] = requests.get(all_url).json()["Stats"]
-    all_by_char_stats[mode] = requests.get(all_by_char_url).json()["Stats"]
+    async with session.get(all_url) as response:
+        all_stats[mode] = (await response.json(content_type=None))["Stats"]
+    async with session.get(all_by_char_url) as response:
+        all_by_char_stats[mode] = (await response.json(content_type=None))["Stats"]
 
-    all_pa, all_avg, all_obp, all_slg = calc_slash_line(all_stats[mode]["Batting"])
+    all_batting = BattingStats.model_validate(all_stats[mode]["Batting"])
+    all_pa, all_avg, all_obp, all_slg = calc_slash_line(all_batting)
     desc = "**Char** (PA): AVG / OBP / SLG, OPS+"
     title = f"\nAll ({all_pa} PA): {all_avg:.3f} / {all_obp:.3f} / {all_slg:.3f}"
 
     try:
         sorted_char_list = sorted(all_by_char_stats[mode].keys(),
-                                  key=lambda x: all_by_char_stats[mode][x]["Batting"]["summary_at_bats"] + all_by_char_stats[mode][x]["Batting"]["summary_walks_bb"] +
-                                                all_by_char_stats[mode][x]["Batting"]["summary_walks_hbp"] + all_by_char_stats[mode][x]["Batting"]["summary_sac_flys"],
+                                  key=lambda x: all_by_char_stats[mode][x]["Batting"].get("summary_at_bats", 0) +
+                                                all_by_char_stats[mode][x]["Batting"].get("summary_walks_bb", 0) +
+                                                all_by_char_stats[mode][x]["Batting"].get("summary_walks_hbp", 0) +
+                                                all_by_char_stats[mode][x]["Batting"].get("summary_sac_flys", 0),
                                   reverse=True)
     except KeyError:
         print("There was an error sorting the character list")
         sorted_char_list = sorted(all_by_char_stats[mode].keys())
 
     for char in sorted_char_list:
-        char_stats = all_by_char_stats[mode][char]["Batting"]
+        char_stats = BattingStats.model_validate(all_by_char_stats[mode][char]["Batting"])
         pa, avg, obp, slg = calc_slash_line(char_stats)
 
         ops_plus = ((obp / all_obp) + (slg / all_slg) - 1) * 100
@@ -230,13 +248,10 @@ async def ostat_all(ctx, mode: str):
     await ctx.send(embed=embed)
 
 
-def calc_slash_line(raw_dict):
-    pa = sum(raw_dict.get(key, 0) for key in
-             ["summary_at_bats", "summary_walks_bb", "summary_walks_hbp", "summary_sac_flys"])
-    avg = raw_dict["summary_hits"] / raw_dict["summary_at_bats"] if raw_dict["summary_at_bats"] > 0 else 0
-    obp = (raw_dict["summary_hits"] + raw_dict["summary_walks_hbp"] + raw_dict[
-        "summary_walks_bb"]) / pa if pa > 0 else 0
-    slg = (raw_dict["summary_singles"] + (raw_dict["summary_doubles"] * 2) + (
-            raw_dict["summary_triples"] * 3) + (raw_dict["summary_homeruns"] * 4)) / raw_dict["summary_at_bats"] if \
-    raw_dict["summary_at_bats"] > 0 else 0
+def calc_slash_line(stats: BattingStats):
+    pa = stats.summary_at_bats + stats.summary_walks_bb + stats.summary_walks_hbp + stats.summary_sac_flys
+    avg = stats.summary_hits / stats.summary_at_bats if stats.summary_at_bats > 0 else 0
+    obp = (stats.summary_hits + stats.summary_walks_hbp + stats.summary_walks_bb) / pa if pa > 0 else 0
+    slg = (stats.summary_singles + (stats.summary_doubles * 2) + (stats.summary_triples * 3) + (
+            stats.summary_homeruns * 4)) / stats.summary_at_bats if stats.summary_at_bats > 0 else 0
     return pa, avg, obp, slg

--- a/main/helpers/pitching_stat_calcs.py
+++ b/main/helpers/pitching_stat_calcs.py
@@ -1,9 +1,11 @@
 import math
 
+import aiohttp
 import discord
-import requests
 from json import JSONDecodeError
 from resources import characters
+from models.pitching_stats import PitchingStats
+from models.misc_stats import MiscStats
 
 BASE_WEB_URL = "https://api.projectrio.app/stats/"
 
@@ -11,16 +13,18 @@ all_stats = {}
 all_by_char_stats = {}
 
 
-async def pstat_user_char(ctx, user: str, char: str, mode: str):
+async def pstat_user_char(ctx, user: str, char: str, mode: str, session: aiohttp.ClientSession):
     global all_by_char_stats
     try:
         all_by_char_url = f"{BASE_WEB_URL}?exclude_batting=1&exclude_fielding=1&tag={mode}&by_char=1"
         char_id = characters.reverse_mappings[char]
         url = f"{BASE_WEB_URL}?exclude_batting=1&exclude_fielding=1&tag={mode}&char_id={char_id}&by_char=1&username={user}"
-        response = requests.get(url).json()
+        async with session.get(url) as response:
+            data = await response.json(content_type=None)
         if not all_by_char_stats.get(mode, {}).get("Pitching", {}):
-            all_by_char_stats[mode] = requests.get(all_by_char_url).json()["Stats"]
-        stats = response.get("Stats", {}).get(char, {}).get("Pitching", {})
+            async with session.get(all_by_char_url) as response:
+                all_by_char_stats[mode] = (await response.json(content_type=None))["Stats"]
+        stats = PitchingStats.model_validate(data.get("Stats", {}).get(char, {}).get("Pitching", {}))
     except (JSONDecodeError, KeyError):
         embed = discord.Embed(
             title=f"There are no stats for user {user} with character {char} in {mode} or the user/character alias was not found.",
@@ -30,31 +34,31 @@ async def pstat_user_char(ctx, user: str, char: str, mode: str):
 
     ip, avg, k_rate, era = calc_slash_line(stats)
 
-    all_char_stats = all_by_char_stats.get(mode, {}).get(char, {}).get("Pitching", {})
+    all_char_stats = PitchingStats.model_validate(all_by_char_stats.get(mode, {}).get(char, {}).get("Pitching", {}))
     overall_ip, overall_avg, overall_k_rate, overall_era = calc_slash_line(all_char_stats)
     era_minus = ((era / overall_era) * 100) if overall_era > 0 and overall_ip > 0 else 200
 
-    misc = response.get("Stats", {}).get(char, {}).get("Misc", {})
-    games = misc["home_wins"] + misc["away_wins"] + misc["home_loses"] + misc["away_loses"]
-    winrate = (misc["home_wins"] + misc["away_wins"]) / games if games > 0 else 0
+    misc = MiscStats.model_validate(data.get("Stats", {}).get(char, {}).get("Misc", {}))
+    games = misc.home_wins + misc.away_wins + misc.home_loses + misc.away_loses
+    winrate = (misc.home_wins + misc.away_wins) / games if games > 0 else 0
 
-    ip_str = str(math.floor(ip)) + "." + str(stats.get("outs_pitched", 0) % 3)
+    ip_str = str(math.floor(ip)) + "." + str(stats.outs_pitched % 3)
     embed = discord.Embed(title=f"{user} - {char} ({ip_str} IP)")
     fields = [("G", str(games)),
               ("Win%", "{:.1f}".format(winrate * 100)),
-              ("Batters Faced", str(stats["batters_faced"])),
-              ("Hits Allowed", str(stats["hits_allowed"])),
-              ("IP", str(round(stats.get("outs_pitched", 0) / 3, 1))),
-              ("Runs Allowed", str(stats["runs_allowed"])),
-              ("\u200b", "\u200b"),
-              ("K", str(stats["strikeouts_pitched"])),
-              ("BB", str(stats["walks_bb"] + stats["walks_hbp"])),
-              ("\u200b", "\u200b"),
+              ("Batters Faced", str(stats.batters_faced)),
+              ("Hits Allowed", str(stats.hits_allowed)),
+              ("IP", str(round(stats.outs_pitched / 3, 1))),
+              ("Runs Allowed", str(stats.runs_allowed)),
+              ("​", "​"),
+              ("K", str(stats.strikeouts_pitched)),
+              ("BB", str(stats.walks_bb + stats.walks_hbp)),
+              ("​", "​"),
               ("Opp. AVG", "{:.3f}".format(avg)),
               ("K%", "{:.1%}".format(k_rate)),
               ("ERA", "{:.2f}".format(era)),
               ("ERA-", str(round(era_minus))),
-              ("\u200b", "\u200b")]
+              ("​", "​")]
 
     for name, value in fields:
         embed.add_field(name=name, value=value, inline=True)
@@ -64,7 +68,7 @@ async def pstat_user_char(ctx, user: str, char: str, mode: str):
     await ctx.send(embed=embed)
 
 
-async def pstat_user(ctx, user: str, mode: str):
+async def pstat_user(ctx, user: str, mode: str, session: aiohttp.ClientSession):
     global all_stats, all_by_char_stats
     all_url = f"{BASE_WEB_URL}?exclude_batting=1&exclude_fielding=1&exclude_misc=1&tag={mode}"
     user_url = f"{all_url}&username={user}"
@@ -73,32 +77,40 @@ async def pstat_user(ctx, user: str, mode: str):
     try:
         if not all_stats.get(mode, {}).get("Pitching", {}):
             print("getting all stats")
-            all_stats[mode] = requests.get(all_url).json()["Stats"]
+            async with session.get(all_url) as response:
+                all_stats[mode] = (await response.json(content_type=None))["Stats"]
         if not all_by_char_stats.get(mode, {}):
             print("Getting all by char stats")
-            all_by_char_stats[mode] = requests.get(all_by_char_url).json()["Stats"]
-        user_response = requests.get(user_url).json()
-        user_by_char_response = requests.get(user_by_char_url).json()
-    except JSONDecodeError:
+            async with session.get(all_by_char_url) as response:
+                all_by_char_stats[mode] = (await response.json(content_type=None))["Stats"]
+        async with session.get(user_url) as response:
+            user_response = await response.json(content_type=None)
+        async with session.get(user_by_char_url) as response:
+            user_by_char_response = await response.json(content_type=None)
+    except (JSONDecodeError, KeyError):
         embed = discord.Embed(
             title=f"There are no stats for user {user} in {mode} or the username was not found.",
             color=0xEA7D07)
         await ctx.send(embed=embed)
         return
 
-    user_dict = {"all": user_response["Stats"]["Pitching"]}
+    user_dict: dict[str, PitchingStats] = {
+        "all": PitchingStats.model_validate(user_response["Stats"]["Pitching"])
+    }
     for char in user_by_char_response["Stats"]:
-        user_dict[char] = user_by_char_response["Stats"][char]["Pitching"]
+        user_dict[char] = PitchingStats.model_validate(user_by_char_response["Stats"][char]["Pitching"])
 
     user_stats = user_dict["all"]
     ip, avg, k_rate, era = calc_slash_line(user_stats)
 
-    overall_ip, overall_avg, overall_k_rate, overall_era = calc_slash_line(all_stats[mode]["Pitching"])
+    overall_ip, overall_avg, overall_k_rate, overall_era = calc_slash_line(
+        PitchingStats.model_validate(all_stats[mode]["Pitching"])
+    )
     if overall_era > 0 and overall_ip > 0:
         era_minus = (era / overall_era) * 100
     else:
         era_minus = 200
-    ip_str = str(math.floor(ip)) + "." + str(user_stats.get("outs_pitched", 0) % 3)
+    ip_str = str(math.floor(ip)) + "." + str(user_stats.outs_pitched % 3)
     title = f"\n{user} ({ip_str} IP): {avg:.3f} / {k_rate:.1%} / {era:.2f} ERA, {round(era_minus)} ERA-"
 
     desc = "**Char** (IP): Opp. AVG / K% / ERA, cERA-"
@@ -106,7 +118,7 @@ async def pstat_user(ctx, user: str, mode: str):
     del user_dict["all"]
     try:
         sorted_char_list = sorted(user_dict.keys(),
-                                  key=lambda x: user_dict[x].get("outs_pitched", 0),
+                                  key=lambda x: user_dict[x].outs_pitched,
                                   reverse=True)
     except KeyError:
         print("There was an error sorting the character list")
@@ -115,14 +127,14 @@ async def pstat_user(ctx, user: str, mode: str):
     for char in sorted_char_list:
         char_stats = user_dict[char]
         ip, avg, k_rate, era = calc_slash_line(char_stats)
-        all_char_stats = all_by_char_stats[mode][char]["Pitching"]
+        all_char_stats = PitchingStats.model_validate(all_by_char_stats[mode][char]["Pitching"])
         overall_ip, overall_avg, overall_k_rate, overall_era = calc_slash_line(all_char_stats)
         if overall_ip > 0 and overall_era > 0:
             era_minus = (era / overall_era) * 100
         else:
             era_minus = 200
-        if char_stats['batters_faced'] > 0 and char_stats.get("outs_pitched", 0) > 3:
-            ip_str = str(math.floor(ip)) + "." + str(char_stats.get("outs_pitched", 0) % 3)
+        if char_stats.batters_faced > 0 and char_stats.outs_pitched > 3:
+            ip_str = str(math.floor(ip)) + "." + str(char_stats.outs_pitched % 3)
             desc += f'\n**{char}** ({ip_str} IP): {avg:.3f} / {k_rate:.1%} / {era:.2f}, {round(era_minus)} cERA-'
 
     embed = discord.Embed(title=title, description=desc)
@@ -132,7 +144,7 @@ async def pstat_user(ctx, user: str, mode: str):
     await ctx.send(embed=embed)
 
 
-async def pstat_char(ctx, char: str, mode: str):
+async def pstat_char(ctx, char: str, mode: str, session: aiohttp.ClientSession):
     try:
         all_url = f"{BASE_WEB_URL}?exclude_batting=1&exclude_fielding=1&exclude_misc=1&tag={mode}"
         if char != "all":
@@ -142,8 +154,10 @@ async def pstat_char(ctx, char: str, mode: str):
             char_url = all_url
             char_by_user_url = all_url + "&by_user=1"
 
-        char_response = requests.get(char_url).json()
-        char_by_user_response = requests.get(char_by_user_url).json()
+        async with session.get(char_url) as response:
+            char_response = await response.json(content_type=None)
+        async with session.get(char_by_user_url) as response:
+            char_by_user_response = await response.json(content_type=None)
     except (JSONDecodeError, KeyError):
         embed = discord.Embed(
             title=f"There are no stats for character {char} in {mode} or the character alias was not found.",
@@ -151,14 +165,15 @@ async def pstat_char(ctx, char: str, mode: str):
         await ctx.send(embed=embed)
         return
 
-    user_list = [("all", char_response["Stats"]["Pitching"])]
-
+    user_list: list[tuple[str, PitchingStats]] = [
+        ("all", PitchingStats.model_validate(char_response["Stats"]["Pitching"]))
+    ]
     for user, stats in char_by_user_response["Stats"].items():
-        user_list.append((user, stats["Pitching"]))
+        user_list.append((user, PitchingStats.model_validate(stats["Pitching"])))
 
     char_stats = user_list[0][1]
     ip, avg, k_rate, era = calc_slash_line(char_stats)
-    ip_str = str(math.floor(ip)) + "." + str(char_stats.get("outs_pitched", 0) % 3)
+    ip_str = str(math.floor(ip)) + "." + str(char_stats.outs_pitched % 3)
 
     title = f"\n{char} ({ip_str} IP): {avg:.3f} Opp. AVG / {k_rate:.1%} K% / {era:.2f} ERA"
     desc = "**User** (IP): Opp. AVG / K% / ERA, ERA-"
@@ -172,7 +187,7 @@ async def pstat_char(ctx, char: str, mode: str):
             era_minus = 200
 
         if user_ip > (ip / 100):
-            user_ip_str = str(math.floor(user_ip)) + "." + str(user_stats.get("outs_pitched", 0) % 3)
+            user_ip_str = str(math.floor(user_ip)) + "." + str(user_stats.outs_pitched % 3)
             output_list.append((user, user_ip_str, user_avg, user_k_rate, user_era, era_minus))
 
     sorted_user_list = sorted(output_list, key=lambda x: x[5], reverse=False)
@@ -193,16 +208,19 @@ async def pstat_char(ctx, char: str, mode: str):
     await ctx.send(embed=embed)
 
 
-async def pstat_all(ctx, mode: str):
+async def pstat_all(ctx, mode: str, session: aiohttp.ClientSession):
     global all_stats, all_by_char_stats
     all_url = BASE_WEB_URL + "?exclude_batting=1&exclude_fielding=1&exclude_misc=1&tag=" + mode
     all_by_char_url = all_url + "&by_char=1"
 
-    all_stats[mode] = requests.get(all_url).json()["Stats"]
-    all_by_char_stats[mode] = requests.get(all_by_char_url).json()["Stats"]
+    async with session.get(all_url) as response:
+        all_stats[mode] = (await response.json(content_type=None))["Stats"]
+    async with session.get(all_by_char_url) as response:
+        all_by_char_stats[mode] = (await response.json(content_type=None))["Stats"]
 
-    all_ip, all_avg, all_k_rate, all_era = calc_slash_line(all_stats[mode]["Pitching"])
-    all_ip_str = str(math.floor(all_ip)) + "." + str(all_stats.get("outs_pitched", 0) % 3)
+    all_pitching = PitchingStats.model_validate(all_stats[mode]["Pitching"])
+    all_ip, all_avg, all_k_rate, all_era = calc_slash_line(all_pitching)
+    all_ip_str = str(math.floor(all_ip)) + "." + str(all_pitching.outs_pitched % 3)
     desc = "**Char** (IP): Opp AVG / K% / ERA, ERA-"
     title = f"\nAll ({all_ip_str} IP): {all_avg:.3f} Opp. AVG / {all_k_rate:.1%} K% / {all_era:.2f} ERA"
 
@@ -215,12 +233,12 @@ async def pstat_all(ctx, mode: str):
         sorted_char_list = sorted(all_by_char_stats[mode].keys())
 
     for char in sorted_char_list:
-        char_stats = all_by_char_stats[mode][char]["Pitching"]
+        char_stats = PitchingStats.model_validate(all_by_char_stats[mode][char]["Pitching"])
         ip, avg, k_rate, era = calc_slash_line(char_stats)
 
         era_minus = (era / all_era) * 100
-        if char_stats['batters_faced'] > 0 and char_stats.get("outs_pitched", 0) > 27:
-            ip_str = str(math.floor(ip)) + "." + str(char_stats.get("outs_pitched", 0) % 3)
+        if char_stats.batters_faced > 0 and char_stats.outs_pitched > 27:
+            ip_str = str(math.floor(ip)) + "." + str(char_stats.outs_pitched % 3)
             desc += f"\n**{char}** ({ip_str} IP): {avg:.3f} / {k_rate:.1%} / {era:.2f}, {round(era_minus)} ERA-"
 
     embed = discord.Embed(title=title, description=desc)
@@ -230,10 +248,9 @@ async def pstat_all(ctx, mode: str):
     await ctx.send(embed=embed)
 
 
-def calc_slash_line(raw_dict):
-    ip = sum(raw_dict.get(key, 0) for key in
-             ["outs_pitched"]) / 3
-    avg = raw_dict["hits_allowed"] / (raw_dict["batters_faced"] - raw_dict['walks_bb'] - raw_dict['walks_hbp']) if raw_dict["batters_faced"] > 0 else 0
-    k_rate = (raw_dict["strikeouts_pitched"] / (raw_dict["batters_faced"] - raw_dict['walks_bb'] - raw_dict['walks_hbp'])) if raw_dict['batters_faced'] > 0 else 0
-    era = (9 * raw_dict['runs_allowed']) / ip if ip > 0 else 0
+def calc_slash_line(stats: PitchingStats):
+    ip = stats.outs_pitched / 3
+    avg = stats.hits_allowed / (stats.batters_faced - stats.walks_bb - stats.walks_hbp) if stats.batters_faced > 0 else 0
+    k_rate = stats.strikeouts_pitched / (stats.batters_faced - stats.walks_bb - stats.walks_hbp) if stats.batters_faced > 0 else 0
+    era = (9 * stats.runs_allowed) / ip if ip > 0 else 0
     return ip, avg, k_rate, era

--- a/main/matchmaking.py
+++ b/main/matchmaking.py
@@ -260,7 +260,7 @@ async def check_for_match(bot: commands.Bot, game_type, user_id, min_rating, max
             for player in queue[game_type]:
                 if max_rating >= queue[game_type][player]["Rating"] >= min_rating and player != user_id:
                     if not best_match or abs(queue[game_type][best_match]["Rating"] - queue[game_type][user_id]["Rating"]) \
-                            > abs(queue[game_type][player]["Rating"] - queue[user_id]["Rating"]):
+                            > abs(queue[game_type][player]["Rating"] - queue[game_type][user_id]["Rating"]):
                         best_match = player
 
             # If match is found
@@ -281,7 +281,7 @@ async def check_for_match(bot: commands.Bot, game_type, user_id, min_rating, max
                            match_queue[user_id]["Name"] + " " + str(match_queue[user_id]["Rating"]) + " vs " + \
                            match_queue[best_match]["Name"] + " " + str(match_queue[best_match]["Rating"])
                 print(log_text)
-                with open("match_log.txt", "w") as file:
+                with open("match_log.txt", "a") as file:
                     file.write(log_text)
                 embed = discord.Embed()
 
@@ -293,7 +293,7 @@ async def check_for_match(bot: commands.Bot, game_type, user_id, min_rating, max
                     file = ifBuildTeamImageFile(team_list, captain_list)
                     embed.set_image(url="attachment://image.png")
                     stadium = rfRandomStadium()
-                    if rfFlipCoin == "Heads":
+                    if rfFlipCoin() == "Heads":
                         away = match_queue[user_id]["Name"]
                         home = match_queue[best_match]["Name"]
                     else:

--- a/main/models/batting_stats.py
+++ b/main/models/batting_stats.py
@@ -1,0 +1,37 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class BattingStats(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    # Required — used in calc_slash_line and display
+    summary_at_bats: int
+    summary_hits: int
+    summary_singles: int
+    summary_doubles: int
+    summary_triples: int
+    summary_homeruns: int
+    summary_rbi: int
+    summary_strikeouts: int
+    summary_walks_bb: int
+    summary_walks_hbp: int
+    summary_sac_flys: int
+    perfect_hits: int
+    nice_hits: int
+    sour_hits: int
+
+    # Optional — modeled for future use
+    summary_bases_stolen: int = 0
+    plate_appearances: int = 0
+    singles: int = 0
+    doubles: int = 0
+    triples: int = 0
+    homeruns: int = 0
+    rbi: int = 0
+    strikeouts: int = 0
+    sacflys: int = 0
+    outs: int = 0
+    fair_hits: int = 0
+    foul_hits: int = 0
+    gidps: int = 0
+    star_hits: int = 0

--- a/main/models/game.py
+++ b/main/models/game.py
@@ -1,0 +1,26 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class Game(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    # Required — actively used in recent_games.py
+    home_user: str
+    away_user: str
+    home_score: int
+    away_score: int
+    home_captain: str
+    away_captain: str
+    date_time_start: int
+    innings_played: int
+    innings_selected: int
+    stadium: int
+    game_mode: int
+
+    # Optional — modeled for future use
+    game_id: int = 0
+    date_time_end: int = 0
+    winner_incoming_elo: int = 0
+    winner_result_elo: int = 0
+    loser_incoming_elo: int = 0
+    loser_result_elo: int = 0

--- a/main/models/misc_stats.py
+++ b/main/models/misc_stats.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class MiscStats(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    # Required — used in games/winrate calculations
+    home_wins: int
+    away_wins: int
+    home_loses: int
+    away_loses: int
+
+    # Optional — modeled for future use
+    game_appearances: int = 0

--- a/main/models/pitching_stats.py
+++ b/main/models/pitching_stats.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class PitchingStats(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    # Required — used in calc_slash_line and display
+    batters_faced: int
+    outs_pitched: int
+    hits_allowed: int
+    runs_allowed: int
+    strikeouts_pitched: int
+    walks_bb: int
+    walks_hbp: int
+
+    # Optional — modeled for future use
+    total_pitches: int = 0
+    strikes: int = 0
+    balls: int = 0
+    star_pitches_thrown: int = 0

--- a/main/models/tag_set.py
+++ b/main/models/tag_set.py
@@ -1,0 +1,33 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class Tag(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    # All Tag fields are optional — Tag is not directly used in any logic yet
+    id: int = 0
+    name: str = ""
+    type: str = ""
+    desc: str = ""
+    active: bool = True
+    comm_id: int = 0
+    date_created: int = 0
+    gecko_code: str = ""
+    gecko_code_desc: str = ""
+
+
+class TagSet(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    # Required — used in mode filtering and lookups
+    id: int
+    name: str
+    comm_type: str
+    start_date: float
+    end_date: float
+
+    # Optional — modeled for future use
+    comm_id: int = 0
+    gecko_code: str = ""
+    tag_ids: list[int] = []
+    tags: list[Tag] = []

--- a/main/resources/ladders.py
+++ b/main/resources/ladders.py
@@ -1,9 +1,18 @@
 import time
 
+import aiohttp
 from discord.ext import tasks
 import requests
 from helpers import utils
+from models.tag_set import TagSet
 import math
+
+_session: aiohttp.ClientSession | None = None
+
+
+def set_session(session: aiohttp.ClientSession):
+    global _session
+    _session = session
 
 # Rating adjustment constants
 BETA = 0.85
@@ -11,24 +20,23 @@ ALPHA = 0.1
 
 modes_body = {'Client': 'true', 'Active': 'true', 'combine_codes': True}
 
-modes = requests.post("https://api.projectrio.app/tag_set/list", json=modes_body).json()["Tag Sets"]
+modes = [TagSet.model_validate(m) for m in requests.post("https://api.projectrio.app/tag_set/list", json=modes_body).json()["Tag Sets"]]
 
 all_modes_body = {
     "Client": "true"
 }
 
-all_modes = requests.post("https://api.projectrio.app/tag_set/list", json=all_modes_body).json()["Tag Sets"]
+all_modes: list[TagSet] = [TagSet.model_validate(m) for m in requests.post("https://api.projectrio.app/tag_set/list", json=all_modes_body).json()["Tag Sets"]]
 
 current_time = time.time()
 active_official_modes = [mode for mode in all_modes if
-                         mode["comm_type"] == "Official" and mode["start_date"] < current_time < mode["end_date"]]
+                         mode.comm_type == "Official" and mode.start_date < current_time < mode.end_date]
 
 
 def get_official_game_mode(ending: str):
     for mode in active_official_modes:
-        name: str = mode["name"]
-        if name.lower().endswith(ending.lower()):
-            return name
+        if mode.name.lower().endswith(ending.lower()):
+            return mode.name
     return "Not Found"
 
 
@@ -66,9 +74,14 @@ def find_game_mode(mode: str):
     return mode
 
 
-def get_game_mode_name(mode_id: int):
-    game_mode = next(x for x in all_modes if mode_id == x["id"])
-    return game_mode["name"]
+async def get_game_mode_name(mode_id: int):
+    global all_modes
+    game_mode = next((x for x in all_modes if mode_id == x.id), None)
+    if game_mode is None:
+        async with _session.post("https://api.projectrio.app/tag_set/list", json=all_modes_body) as response:
+            all_modes = [TagSet.model_validate(m) for m in (await response.json(content_type=None))["Tag Sets"]]
+        game_mode = next((x for x in all_modes if mode_id == x.id), None)
+    return game_mode.name if game_mode else "Unknown"
 
 
 def get_web_mode(mode: str):
@@ -81,7 +94,8 @@ async def refresh_ladders():
 
     for mode in ladders:
         ladder_body = {"TagSet": mode}
-        ladders[mode] = requests.post("https://api.projectrio.app/tag_set/ladder", json=ladder_body).json()
+        async with _session.post("https://api.projectrio.app/tag_set/ladder", json=ladder_body) as response:
+            ladders[mode] = await response.json(content_type=None)
         for user in ladders[mode]:
             player_wins = ladders[mode][user]["num_wins"]
             player_games = ladders[mode][user]["num_wins"] + ladders[mode][user]["num_losses"] + 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
+aiohttp==3.11.18
 discord.py==2.5.2
+pydantic==2.11.5
 glicko2==2.1.0
 gspread==5.7.1
 oauth2client==4.1.3

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -1,18 +1,21 @@
 echo "Installing dependencies for RioBot"
 
-# Installing Python3 manually to get 3.11 instead of 3.7
-# yum install -y python3, python3-pip
-yum install -y gcc openssl-devel bzip2-devel libffi-devel zlib
+if ! command -v python3.9 &> /dev/null; then
+    echo "Python 3.9 not found, installing..."
+    yum install -y gcc openssl-devel bzip2-devel libffi-devel zlib
 
-cd /opt
-wget https://www.python.org/ftp/python/3.9.6/Python-3.9.6.tgz
-tar xzf Python-3.9.6.tgz
+    cd /opt
+    wget https://www.python.org/ftp/python/3.9.6/Python-3.9.6.tgz
+    tar xzf Python-3.9.6.tgz
 
-cd Python-3.9.6
-./configure --enable-optimizations
-make altinstall
+    cd Python-3.9.6
+    ./configure --enable-optimizations
+    make altinstall
 
-rm -f /opt/Python-3.9.6.tgz
+    rm -f /opt/Python-3.9.6.tgz
+else
+    echo "Python 3.9 already installed, skipping."
+fi
 
 /usr/local/bin/python3.9 -m pip install --upgrade pip
-/usr/local/bin/pip3.9 install -U discord.py==2.5.2 glicko2==2.1.0 gspread==5.7.1 oauth2client==4.1.3 Pillow==11.3.0 python-dotenv==1.1.1 pytz==2025.2 requests==2.32.4
+/usr/local/bin/pip3.9 install -r /home/ec2-user/RioBot/requirements.txt

--- a/scripts/run_service.sh
+++ b/scripts/run_service.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 echo "Running RioBot"
 cd /home/ec2-user/RioBot/main
-sudo nohup python3.9 RioBot.py
+sudo nohup python3.9 RioBot.py > /var/log/riobot.log 2>&1 &


### PR DESCRIPTION
  Summary

  - Migrate from requests to aiohttp across all async command handlers to fix Discord gateway heartbeat blocking warnings. A shared aiohttp.ClientSession is created in setup_hook and passed through to all stat lookup helpers
  and resource modules.
  - Add Pydantic v2 models (Game, TagSet, BattingStats, PitchingStats, MiscStats) to replace raw dicts throughout the codebase. Fields actively used in calculations are required (fail-fast on missing data); additional API
  fields are modeled with defaults for future use.
  - Fix matchmaking bugs: missing game_type key in best-match rating comparison (was silently rolling back every match), rfFlipCoin called as a value instead of a function (home/away was always the same), and match log being
  overwritten instead of appended.
  - Fix !submit race condition: concurrent submissions would both trigger on any approval reaction from pokebunny. Reactions are now scoped to the specific submission message ID. Also added ❌ rejection reaction.
  - Fix bot architecture: move cog loading to setup_hook (runs once) instead of on_ready (fires on every reconnect), guard background task starts with is_running() checks.
  - Fix deploy stability: run_service.sh was blocking the CodeDeploy ApplicationStart script, hitting the 5-minute timeout and killing the bot. Added & to background the process. Also guard Python reinstall in
  install_dependencies.sh and use requirements.txt instead of a hardcoded package list.
  - Change !last and !h2h default mode from off to all.