### PR TITLE
Add pytest harness + starter unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [ master ]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ main/resources/test_BACKUP.json
 main/.env
 main/resources/test.json
 /scratch/
+.git_commit_msg.tmp
 /.claude/settings.local.json
 /main/.env_PROD

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,3 +48,18 @@ The root logger is configured by `bot.run(..., root_logger=True)` in `RioBot.py`
 Ladder/stat data comes from the Project Rio API (`https://api.projectrio.app`).
 `resources/ladders.py` fetches game modes at import (with startup retries) and
 refreshes ladders on a loop.
+
+## Development
+
+Runtime deps live in `requirements.txt`; dev-only tooling (ruff, pytest) lives in
+`requirements-dev.txt` and is never installed on the bot runtime. Install both
+locally with `pip install -r requirements.txt -r requirements-dev.txt`.
+
+- **Lint/format:** `ruff check .` and `ruff format .`. Config is in
+  `pyproject.toml`. CI enforces `ruff check` on every PR.
+- **Tests:** `pytest` from the repo root. Tests live in `tests/` (outside `main/`,
+  so they don't ship to prod) and import app modules via the `pythonpath = ["main"]`
+  setting in `pyproject.toml`. CI runs the suite on every PR.
+- Tests cover pure logic (stat calcs, sorting, model validation) and stay offline.
+  Modules that hit the Project Rio API or Discord at import (`resources/ladders.py`,
+  the cogs) are intentionally untested for now — they'd need mocking.

--- a/main/RioBot.py
+++ b/main/RioBot.py
@@ -10,6 +10,7 @@ import discord
 import pytz
 from discord.ext import commands, tasks
 from dotenv import load_dotenv
+
 from helpers import offensive_stat_calcs, pitching_stat_calcs
 from resources import ladders
 

--- a/main/cogs/classic_teams.py
+++ b/main/cogs/classic_teams.py
@@ -1,5 +1,6 @@
 import discord
 from discord.ext import commands
+
 from helpers.classic_teams_parser import ClassicTeam, build_classic_teams
 from services.classic_teams_service import (
     get_classic_draft_quote,

--- a/main/cogs/game_stat_lookup.py
+++ b/main/cogs/game_stat_lookup.py
@@ -1,5 +1,6 @@
 import discord
 from discord.ext import commands
+
 from resources import CharacterStats
 from resources import EnvironmentVariables as ev
 from resources.characters import BAT_URLS

--- a/main/cogs/ladder.py
+++ b/main/cogs/ladder.py
@@ -2,6 +2,7 @@ import urllib.parse
 
 import discord
 from discord.ext import commands
+
 from helpers.stat_utils import FRONTEND_URL
 from resources import EnvironmentVariables as ev
 from resources import ladders

--- a/main/cogs/matchmaking.py
+++ b/main/cogs/matchmaking.py
@@ -4,6 +4,7 @@ import discord
 from discord import ButtonStyle
 from discord.ext import commands, tasks
 from matchmaker import BUTTON_CHANNEL_ID, Matchmaker
+
 from resources import ladders
 
 logger = logging.getLogger(__name__)

--- a/main/cogs/misc.py
+++ b/main/cogs/misc.py
@@ -1,5 +1,6 @@
 import discord
 from discord.ext import commands
+
 from resources import EnvironmentVariables as ev
 
 

--- a/main/cogs/randomize_commands.py
+++ b/main/cogs/randomize_commands.py
@@ -1,5 +1,6 @@
 import discord
 from discord.ext import commands
+
 from helpers.random_team_builder import (
     random_balanced_teams,
     random_power_teams,

--- a/main/cogs/recent_games.py
+++ b/main/cogs/recent_games.py
@@ -1,5 +1,6 @@
 import discord
 from discord.ext import commands
+
 from models.game import Game
 from resources import ladders
 

--- a/main/cogs/registration.py
+++ b/main/cogs/registration.py
@@ -2,6 +2,7 @@ from json import JSONDecodeError
 
 import discord
 from discord.ext import commands
+
 from resources import EnvironmentVariables as ev
 from resources import rio_name_map
 

--- a/main/cogs/submit_results.py
+++ b/main/cogs/submit_results.py
@@ -5,6 +5,7 @@ import os
 import discord
 from discord.ext import commands
 from dotenv import load_dotenv
+
 from resources import EnvironmentVariables as ev
 
 logger = logging.getLogger(__name__)

--- a/main/cogs/web_stat_lookup.py
+++ b/main/cogs/web_stat_lookup.py
@@ -1,4 +1,5 @@
 from discord.ext import commands
+
 from helpers.offensive_stat_calcs import ostat_all, ostat_char, ostat_user, ostat_user_char
 from helpers.pitching_stat_calcs import pstat_all, pstat_char, pstat_user, pstat_user_char
 from resources import characters, ladders

--- a/main/helpers/classic_teams_parser.py
+++ b/main/helpers/classic_teams_parser.py
@@ -3,6 +3,7 @@ from random import shuffle
 
 from helpers.utils import ordinal
 from resources.characters import Char
+from resources.paths import RESOURCES_DIR
 
 # Static variables of which row in the CSV are which
 league_row = 0
@@ -76,7 +77,7 @@ def build_character_list(char_row):
 
 
 def build_classic_teams():
-    with open("resources/ClassicTeams.csv", "r") as file:
+    with open(RESOURCES_DIR / "ClassicTeams.csv", "r") as file:
         reader = csv.reader(file)
         for row in reader:
             classic_team_leagues.append(row[league_row].lower())

--- a/main/helpers/offensive_stat_calcs.py
+++ b/main/helpers/offensive_stat_calcs.py
@@ -3,6 +3,7 @@ from json import JSONDecodeError
 
 import aiohttp
 import discord
+
 from helpers import stat_cache
 from helpers.stat_utils import BASE_STATS_URL, FRONTEND_URL, send_error_embed, send_stat_embed
 from models.batting_stats import BattingStats

--- a/main/helpers/pitching_stat_calcs.py
+++ b/main/helpers/pitching_stat_calcs.py
@@ -4,6 +4,7 @@ from json import JSONDecodeError
 
 import aiohttp
 import discord
+
 from helpers import stat_cache
 from helpers.stat_utils import BASE_STATS_URL, send_error_embed, send_stat_embed
 from models.misc_stats import MiscStats

--- a/main/helpers/stat_utils.py
+++ b/main/helpers/stat_utils.py
@@ -1,4 +1,5 @@
 import discord
+
 from resources import characters
 
 BASE_STATS_URL = "https://api.projectrio.app/stats/"

--- a/main/matchmaker.py
+++ b/main/matchmaker.py
@@ -5,6 +5,7 @@ import time
 
 import discord
 from discord.ext import commands
+
 from models.matchmaking import MatchAnnouncement, QueuedPlayer
 from resources import EnvironmentVariables as ev
 from resources import ladders, rio_name_map

--- a/main/resources/CharacterStats.py
+++ b/main/resources/CharacterStats.py
@@ -1,5 +1,7 @@
 import csv
 
+from resources.paths import RESOURCES_DIR
+
 
 # returns row index of character in csv
 # arg1: >= 0 is index of character, -1 = character DNE, -2 = 'highest', -3 = 'lowest', -4 = 'average'
@@ -46,11 +48,11 @@ def build_stat_objs():
     # make LoL's
     char_name_list = []
     stats_name_list = []
-    with open("resources/CharNames.csv", "r") as file:
+    with open(RESOURCES_DIR / "CharNames.csv", "r") as file:
         reader = csv.reader(file)
         for row in reader:
             char_name_list.append(row)
-    with open("resources/StatNames.csv", "r") as file:
+    with open(RESOURCES_DIR / "StatNames.csv", "r") as file:
         reader = csv.reader(file)
         for row in reader:
             stats_name_list.append(row)
@@ -65,7 +67,7 @@ def build_stat_objs():
 
 
 def build_stats_lol(lolref):
-    with open("resources/Stats.csv", "r") as file:
+    with open(RESOURCES_DIR / "Stats.csv", "r") as file:
         reader = csv.reader(file)
         for row in reader:
             lolref.append(row)

--- a/main/resources/EnvironmentVariables.py
+++ b/main/resources/EnvironmentVariables.py
@@ -1,10 +1,11 @@
 import json
-from os.path import exists
 
-prod_env = "resources/prod.json"
-dev_env = "resources/test.json"
+from resources.paths import RESOURCES_DIR
 
-_env_file = dev_env if exists(dev_env) else prod_env
+_prod_env = RESOURCES_DIR / "prod.json"
+_dev_env = RESOURCES_DIR / "test.json"
+
+_env_file = _dev_env if _dev_env.exists() else _prod_env
 with open(_env_file) as _f:
     _vars = json.load(_f)
 

--- a/main/resources/ladders.py
+++ b/main/resources/ladders.py
@@ -5,6 +5,7 @@ import time
 import aiohttp
 import requests
 from discord.ext import tasks
+
 from helpers import utils
 from models.tag_set import TagSet
 

--- a/main/resources/paths.py
+++ b/main/resources/paths.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+
+# Absolute path to the resources/ directory, anchored to this file rather than
+# the process working directory. Data files (CSVs, JSON config) load reliably no
+# matter where the bot is started from.
+RESOURCES_DIR = Path(__file__).resolve().parent

--- a/main/services/matchmaking_embeds.py
+++ b/main/services/matchmaking_embeds.py
@@ -1,4 +1,5 @@
 import discord
+
 from helpers.random_team_builder import random_teams_without_dupes
 from models.matchmaking import MatchAnnouncement
 from resources import EnvironmentVariables as ev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,13 @@ extend-exclude = ["venv", ".venv", "scratch"]
 select = ["E", "F", "I"]
 # Line length is deferred to the formatter pass (step 3), so don't flag it yet.
 ignore = ["E501"]
+
+[tool.ruff.lint.isort]
+# These live under main/ (the import root), so isort can't infer they're ours.
+known-first-party = ["cogs", "helpers", "models", "resources", "services"]
+
+[tool.pytest.ini_options]
+# The app's import root is main/ (imports are `from helpers...`, `from resources...`).
+# Putting it on the path lets tests import app modules without a cwd dependency.
+pythonpath = ["main"]
+testpaths = ["tests"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 # Dev-only tooling. NOT installed on the bot runtime (keep out of requirements.txt).
 # Pinned so local runs and CI agree; bump deliberately.
 ruff==0.15.18
+pytest==9.1.1

--- a/tests/test_batting_stats.py
+++ b/tests/test_batting_stats.py
@@ -1,0 +1,44 @@
+import pytest
+from pydantic import ValidationError
+
+from models.batting_stats import BattingStats
+
+REQUIRED = {
+    "summary_at_bats": 1,
+    "summary_hits": 1,
+    "summary_singles": 1,
+    "summary_doubles": 0,
+    "summary_triples": 0,
+    "summary_homeruns": 0,
+    "summary_rbi": 0,
+    "summary_strikeouts": 0,
+    "summary_walks_bb": 0,
+    "summary_walks_hbp": 0,
+    "summary_sac_flys": 0,
+}
+
+
+class TestBattingStatsValidation:
+    def test_extra_fields_are_ignored(self):
+        # The API sends more fields than we model; extra="ignore" must not raise.
+        stats = BattingStats.model_validate({**REQUIRED, "some_future_field": 999})
+        assert not hasattr(stats, "some_future_field")
+        assert stats.summary_at_bats == 1
+
+    def test_missing_required_field_raises(self):
+        incomplete = dict(REQUIRED)
+        del incomplete["summary_at_bats"]
+        with pytest.raises(ValidationError):
+            BattingStats.model_validate(incomplete)
+
+    def test_optional_fields_default(self):
+        stats = BattingStats.model_validate(REQUIRED)
+        assert stats.perfect_hits == 0
+        assert stats.nice_hits == 0
+        assert stats.sour_hits == 0
+        assert stats.star_hits == 0
+
+    def test_string_numbers_coerced_to_int(self):
+        # Pydantic coerces numeric strings; the API has historically sent both.
+        stats = BattingStats.model_validate({**REQUIRED, "summary_at_bats": "42"})
+        assert stats.summary_at_bats == 42

--- a/tests/test_slash_line.py
+++ b/tests/test_slash_line.py
@@ -1,0 +1,81 @@
+import pytest
+
+from helpers.offensive_stat_calcs import calc_slash_line
+from models.batting_stats import BattingStats
+
+REQUIRED_DEFAULTS = {
+    "summary_at_bats": 0,
+    "summary_hits": 0,
+    "summary_singles": 0,
+    "summary_doubles": 0,
+    "summary_triples": 0,
+    "summary_homeruns": 0,
+    "summary_rbi": 0,
+    "summary_strikeouts": 0,
+    "summary_walks_bb": 0,
+    "summary_walks_hbp": 0,
+    "summary_sac_flys": 0,
+}
+
+
+def make_batting(**overrides) -> BattingStats:
+    """BattingStats with all required fields zeroed, overridable per test."""
+    return BattingStats(**{**REQUIRED_DEFAULTS, **overrides})
+
+
+class TestCalcSlashLine:
+    def test_typical_line(self):
+        stats = make_batting(
+            summary_at_bats=10,
+            summary_hits=4,
+            summary_singles=2,
+            summary_doubles=1,
+            summary_triples=0,
+            summary_homeruns=1,
+            summary_walks_bb=1,
+        )
+        pa, avg, obp, slg = calc_slash_line(stats)
+        assert pa == 11  # 10 AB + 1 BB
+        assert avg == pytest.approx(0.4)  # 4/10
+        assert obp == pytest.approx(5 / 11)  # (4 hits + 1 BB) / 11 PA
+        assert slg == pytest.approx(0.8)  # (2 + 2 + 4) total bases / 10 AB
+
+    def test_hbp_and_sac_fly_count_toward_pa(self):
+        stats = make_batting(
+            summary_at_bats=3,
+            summary_hits=1,
+            summary_singles=1,
+            summary_walks_bb=1,
+            summary_walks_hbp=1,
+            summary_sac_flys=1,
+        )
+        pa, avg, obp, slg = calc_slash_line(stats)
+        assert pa == 6  # 3 + 1 + 1 + 1
+        assert obp == pytest.approx(3 / 6)  # (1 hit + 1 HBP + 1 BB) / 6 PA
+
+    def test_zero_at_bats_no_division_error(self):
+        # Walked every plate appearance: AVG/SLG guard against /0, OBP still computes.
+        stats = make_batting(summary_walks_bb=2)
+        pa, avg, obp, slg = calc_slash_line(stats)
+        assert pa == 2
+        assert avg == 0
+        assert slg == 0
+        assert obp == pytest.approx(1.0)  # 2 walks / 2 PA
+
+    def test_all_zero_is_all_zero(self):
+        pa, avg, obp, slg = calc_slash_line(make_batting())
+        assert (pa, avg, obp, slg) == (0, 0, 0, 0)
+
+    def test_slugging_weights_extra_base_hits(self):
+        # One of each hit type: total bases = 1 + 2 + 3 + 4 = 10 over 4 AB.
+        stats = make_batting(
+            summary_at_bats=4,
+            summary_hits=4,
+            summary_singles=1,
+            summary_doubles=1,
+            summary_triples=1,
+            summary_homeruns=1,
+        )
+        _, avg, _, slg = calc_slash_line(stats)
+        assert avg == pytest.approx(1.0)
+        assert slg == pytest.approx(2.5)

--- a/tests/test_team_sorter.py
+++ b/tests/test_team_sorter.py
@@ -1,0 +1,47 @@
+from helpers.team_sorter import (
+    get_character_rank,
+    sort_team_by_tier,
+    sort_teams_by_tier_exclude_captain,
+)
+from resources.characters import Char
+
+
+class TestGetCharacterRank:
+    def test_char_enum_member(self):
+        assert get_character_rank(Char.BOWSER) == 1
+        assert get_character_rank(Char.GOOMBA) == 38
+
+    def test_raw_value_in_dict(self):
+        assert get_character_rank(Char.MARIO.value) == 13
+
+    def test_unknown_character_sorts_last(self):
+        assert get_character_rank("Not A Character") == 99
+
+
+class TestSortTeamByTier:
+    def test_sorts_in_place_by_rank(self):
+        team = [Char.GOOMBA, Char.BOWSER, Char.MARIO]
+        sort_team_by_tier(team)
+        # Bowser (1) < Mario (13) < Goomba (38)
+        assert team == [Char.BOWSER, Char.MARIO, Char.GOOMBA]
+
+
+class TestSortTeamsExcludeCaptain:
+    def test_captain_stays_first(self):
+        # Goomba is the captain (worst rank) but must remain at index 0.
+        teams = [[Char.GOOMBA, Char.MARIO, Char.BOWSER]]
+        result = sort_teams_by_tier_exclude_captain(teams)
+        assert result[0][0] == Char.GOOMBA
+        # Remaining players sorted: Bowser (1) before Mario (13).
+        assert result[0][1:] == [Char.BOWSER, Char.MARIO]
+
+    def test_sorts_each_team_independently(self):
+        teams = [
+            [Char.MARIO, Char.GOOMBA, Char.BOWSER],
+            [Char.BOWSER, Char.GOOMBA, Char.MARIO],
+        ]
+        result = sort_teams_by_tier_exclude_captain(teams)
+        assert result[0][0] == Char.MARIO
+        assert result[1][0] == Char.BOWSER
+        assert result[0][1:] == [Char.BOWSER, Char.GOOMBA]
+        assert result[1][1:] == [Char.MARIO, Char.GOOMBA]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,45 @@
+from helpers.utils import ordinal, strip_non_alphanumeric
+
+
+class TestOrdinal:
+    def test_basic_suffixes(self):
+        assert ordinal(1) == "1st"
+        assert ordinal(2) == "2nd"
+        assert ordinal(3) == "3rd"
+        assert ordinal(4) == "4th"
+        assert ordinal(5) == "5th"
+
+    def test_teens_are_th(self):
+        # 11/12/13 are the special case: "th" despite ending in 1/2/3.
+        assert ordinal(11) == "11th"
+        assert ordinal(12) == "12th"
+        assert ordinal(13) == "13th"
+
+    def test_twenties_resume_normal_suffixes(self):
+        assert ordinal(21) == "21st"
+        assert ordinal(22) == "22nd"
+        assert ordinal(23) == "23rd"
+        assert ordinal(24) == "24th"
+
+    def test_hundred_teens_are_th(self):
+        assert ordinal(111) == "111th"
+        assert ordinal(112) == "112th"
+        assert ordinal(113) == "113th"
+        assert ordinal(101) == "101st"
+
+
+class TestStripNonAlphanumeric:
+    def test_removes_punctuation_and_spaces(self):
+        assert strip_non_alphanumeric("Hello, World!") == "helloworld"
+
+    def test_lowercases(self):
+        assert strip_non_alphanumeric("ABC") == "abc"
+
+    def test_keeps_digits(self):
+        assert strip_non_alphanumeric("ABC-123") == "abc123"
+
+    def test_strips_underscores_and_dashes(self):
+        assert strip_non_alphanumeric("  a-b_c  ") == "abc"
+
+    def test_empty_string(self):
+        assert strip_non_alphanumeric("") == ""


### PR DESCRIPTION
## Summary

Adds a pytest harness and the first batch of unit tests, plus a small fix that makes the app runnable from any working directory. Stacked on top of #107 (matchmaking refactor).

## Changes
- **Decouple resource loading from cwd**: data files (config JSON, character/stat CSVs, ClassicTeams.csv) now load relative to a new `resources.paths.RESOURCES_DIR` (anchored to `__file__`) instead of the process working directory. The bot previously only ran correctly when started from `main/`.
- **pytest setup**: `pythonpath=main`, `testpaths=tests`, pinned `pytest` in requirements-dev.txt; ruff isort configured with the app's first-party packages (hence the one-line import-grouping changes across files).
- **Starter tests** (pure logic, no network/discord deps):
  - `helpers.utils`: `ordinal` (incl. 11-13 / 111-113 edge cases), `strip_non_alphanumeric`
  - `helpers.team_sorter`: ranking, tier sorting, captain-stays-first
  - `helpers.offensive_stat_calcs.calc_slash_line`: AVG/OBP/SLG incl. divide-by-zero guards
  - `models.batting_stats`: extra-field ignore, required-field validation, coercion
- **CI**: new Tests workflow runs the suite on PRs and master.

## Notes
- 24 tests, all offline, ~0.3s.
- Network-bound modules (cogs, ladders, API fetchers) are intentionally not covered yet — those need mocking and are lower ROI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
